### PR TITLE
Add multiple command line arguments for UDC, Interface, BT alias

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,10 +15,12 @@ dependencies = [
  "kobject-uevent",
  "log",
  "mac_address",
+ "netif",
  "netlink-sys",
  "protobuf",
  "protobuf-codegen",
  "protoc-bin-vendored",
+ "simple_config_parser",
  "simplelog",
  "tokio",
  "tokio-fd",
@@ -747,6 +749,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "netif"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29a01b9f018d6b7b277fef6c79fdbd9bf17bb2d1e298238055cafab49baa5ee"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "netlink-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,6 +1173,12 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simple_config_parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d562b7cb7cef3d30257e59582674255342665ced8462ad861412e074c653b11"
 
 [[package]]
 name = "simplelog"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ simplelog = { version = "0.11.2", features = ["paris", "ansi_term"] }
 clap = { version = "3.0.13", features = ["derive"] }
 humantime = "2.1.0"
 log = "0.4.22"
+simple_config_parser = "1.0.0"
+netif = "0.1.6"
 
 [build-dependencies]
 protoc-bin-vendored = "3.1.0"

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ OPTIONS:
     -l, --logfile <LOGFILE>           Log file path [default: /var/log/aa-proxy-rs.log]
     -s, --stats-interval <SECONDS>    Interval of showing data transfer statistics (0 = disabled)
                                       [default: 0]
+    -u, --udc <UDCNAME>               Specify UDC Controller to use
     -V, --version                     Print version information
 ```
 Most options are self explanatory, but these needs some more attention:<br>

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ USAGE:
 
 OPTIONS:
     -a, --advertise                   BLE advertising
+    -b, --btalias                     Specify the BLE name of the device
     -c, --connect <CONNECT>           Auto-connect to saved phone or specified phone MAC address if
                                       provided
     -d, --debug                       Enable debug info

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ OPTIONS:
     -c, --connect <CONNECT>           Auto-connect to saved phone or specified phone MAC address if
                                       provided
     -d, --debug                       Enable debug info
+    -i, --interface                   Specify Wi-Fi Hotspot network interface
     -l, --legacy                      Enable legacy mode
     -h, --help                        Print help information
     -l, --logfile <LOGFILE>           Log file path [default: /var/log/aa-proxy-rs.log]

--- a/README.md
+++ b/README.md
@@ -123,17 +123,17 @@ USAGE:
 
 OPTIONS:
     -a, --advertise                   BLE advertising
-    -b, --btalias                     Specify the BLE name of the device
+    -b, --btalias <BTALIAS>           BLE device name
     -c, --connect <CONNECT>           Auto-connect to saved phone or specified phone MAC address if
                                       provided
     -d, --debug                       Enable debug info
-    -i, --interface                   Specify Wi-Fi Hotspot network interface
-    -l, --legacy                      Enable legacy mode
     -h, --help                        Print help information
+    -i, --iface <IFACE>               WLAN / Wi-Fi Hotspot interface [default: wlan0]
+    -l, --legacy                      Enable legacy mode
     -l, --logfile <LOGFILE>           Log file path [default: /var/log/aa-proxy-rs.log]
     -s, --stats-interval <SECONDS>    Interval of showing data transfer statistics (0 = disabled)
                                       [default: 0]
-    -u, --udc <UDCNAME>               Specify UDC Controller to use
+    -u, --udc <UDC>                   UDC Controller name
     -V, --version                     Print version information
 ```
 Most options are self explanatory, but these needs some more attention:<br>

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -7,8 +7,8 @@ use bluer::{
     Adapter, Address, Uuid,
 };
 use futures::StreamExt;
-use simplelog::*;
 use simple_config_parser::Config;
+use simplelog::*;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::io::AsyncReadExt;
@@ -88,7 +88,7 @@ async fn power_up_and_wait_for_connection(
             };
         }
         Some(btalias) => {
-                alias = btalias;
+            alias = btalias;
         }
     }
     info!("{} 🥏 Bluetooth alias: <bold><green>{}</>", NAME, alias);
@@ -361,15 +361,15 @@ pub async fn bluetooth_setup_connection(
 
     let (state, mut stream) = power_up_and_wait_for_connection(advertise, btalias, connect).await?;
 
-    
     // Get UP interface and IP
     for ifa in netif::up().unwrap() {
         match ifa.name() {
             val if val == iface => {
                 debug!("Found interface: {:?}", ifa);
                 // IPv4 Address contains None scope_id, while IPv6 contains Some
-                match ifa.scope_id() { None => {
-                        wlan_ip_addr =  ifa.address().to_string();
+                match ifa.scope_id() {
+                    None => {
+                        wlan_ip_addr = ifa.address().to_string();
                         break;
                     }
                     _ => (),
@@ -380,9 +380,7 @@ pub async fn bluetooth_setup_connection(
     }
 
     // Create a new config from hostapd.conf
-    let hostapd = Config::new()
-        .file(HOSTAPD_FILE)
-        .unwrap();
+    let hostapd = Config::new().file(HOSTAPD_FILE).unwrap();
 
     // read SSID and WPA_KEY
     let wlan_ssid = &hostapd.get_str("ssid").unwrap();
@@ -401,7 +399,10 @@ pub async fn bluetooth_setup_connection(
     let mut info = WifiInfoResponse::new();
     info.set_ssid(String::from(wlan_ssid));
     info.set_key(String::from(wlan_wpa_key));
-    info!("{} 🛜 Sending Host SSID and Password: {}, {}", NAME, wlan_ssid, wlan_wpa_key);
+    info!(
+        "{} 🛜 Sending Host SSID and Password: {}, {}",
+        NAME, wlan_ssid, wlan_wpa_key
+    );
     let bssid = mac_address::mac_address_by_name(iface)
         .unwrap()
         .unwrap()

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -389,7 +389,7 @@ pub async fn bluetooth_setup_connection(
     info!("{} 📲 Sending parameters via bluetooth to phone...", NAME);
     let mut start_req = WifiStartRequest::new();
     info!("{} 🛜 Sending Host IP Address: {}", NAME, wlan_ip_addr);
-    start_req.set_ip_address(String::from(wlan_ip_addr));
+    start_req.set_ip_address(wlan_ip_addr);
     start_req.set_port(TCP_SERVER_PORT);
     send_message(&mut stream, stage, MessageId::WifiStartRequest, start_req).await?;
     stage += 1;

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -78,19 +78,13 @@ async fn power_up_and_wait_for_connection(
     connect: Option<Address>,
 ) -> Result<(BluetoothState, Stream)> {
     // setting BT alias for further use
-    let alias: String;
-
-    match btalias {
-        None => {
-            alias = match get_cpu_serial_number_suffix().await {
-                Ok(suffix) => format!("{}-{}", BT_ALIAS, suffix),
-                Err(_) => String::from(BT_ALIAS),
-            };
-        }
-        Some(btalias) => {
-            alias = btalias;
-        }
-    }
+    let alias = match btalias {
+        None => match get_cpu_serial_number_suffix().await {
+            Ok(suffix) => format!("{}-{}", BT_ALIAS, suffix),
+            Err(_) => String::from(BT_ALIAS),
+        },
+        Some(btalias) => btalias,
+    };
     info!("{} 🥏 Bluetooth alias: <bold><green>{}</>", NAME, alias);
 
     let session = bluer::Session::new().await?;

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -74,13 +74,23 @@ pub async fn get_cpu_serial_number_suffix() -> Result<String> {
 
 async fn power_up_and_wait_for_connection(
     advertise: bool,
+    btalias: Option<String>,
     connect: Option<Address>,
 ) -> Result<(BluetoothState, Stream)> {
     // setting BT alias for further use
-    let alias = match get_cpu_serial_number_suffix().await {
-        Ok(suffix) => format!("{}-{}", BT_ALIAS, suffix),
-        Err(_) => String::from(BT_ALIAS),
-    };
+    let alias: String;
+
+    match btalias {
+        None => {
+            alias = match get_cpu_serial_number_suffix().await {
+                Ok(suffix) => format!("{}-{}", BT_ALIAS, suffix),
+                Err(_) => String::from(BT_ALIAS),
+            };
+        }
+        Some(btalias) => {
+                alias = btalias;
+        }
+    }
     info!("{} 🥏 Bluetooth alias: <bold><green>{}</>", NAME, alias);
 
     let session = bluer::Session::new().await?;
@@ -337,6 +347,7 @@ pub async fn bluetooth_stop(state: BluetoothState) -> Result<()> {
 
 pub async fn bluetooth_setup_connection(
     advertise: bool,
+    btalias: Option<String>,
     iface: &str,
     connect: Option<Address>,
     tcp_start: Arc<Notify>,
@@ -348,7 +359,7 @@ pub async fn bluetooth_setup_connection(
 
     let mut wlan_ip_addr = String::from(DEFAULT_WLAN_ADDR);
 
-    let (state, mut stream) = power_up_and_wait_for_connection(advertise, connect).await?;
+    let (state, mut stream) = power_up_and_wait_for_connection(advertise, btalias, connect).await?;
 
     
     // Get UP interface and IP

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -39,7 +39,7 @@ const BT_ALIAS: &str = "WirelessAADongle";
 
 const DEFAULT_WLAN_ADDR: &str = "10.0.0.1";
 
-const HOSTAPD_FILE: &str = "/etc/hostapd/hostapd.conf";
+const HOSTAPD_FILE: &str = "/etc/hostapd.conf";
 
 #[derive(Debug, Clone, PartialEq)]
 #[repr(u16)]

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -8,6 +8,7 @@ use bluer::{
 };
 use futures::StreamExt;
 use simplelog::*;
+use simple_config_parser::Config;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::io::AsyncReadExt;
@@ -36,10 +37,10 @@ const HSP_HS_UUID: Uuid = Uuid::from_u128(0x0000110800001000800000805f9b34fb);
 const HSP_AG_UUID: Uuid = Uuid::from_u128(0x0000111200001000800000805f9b34fb);
 const BT_ALIAS: &str = "WirelessAADongle";
 
-const WLAN_IFACE: &str = "wlan0";
-const WLAN_IP_ADDR: &str = "10.0.0.1";
-const WLAN_SSID: &str = "AAWirelessDongle";
-const WLAN_WPA_KEY: &str = "ConnectAAWirelessDongle";
+const DEFAULT_WLAN_IFACE: &str = "wlan0";
+const DEFAULT_WLAN_ADDR: &str = "10.0.0.1";
+
+const HOSTAPD_FILE: &str = "/etc/hostapd/hostapd.conf";
 
 #[derive(Debug, Clone, PartialEq)]
 #[repr(u16)]
@@ -345,11 +346,41 @@ pub async fn bluetooth_setup_connection(
     let mut stage = 1;
     let mut started;
 
+    let mut wlan_iface = String::from(DEFAULT_WLAN_IFACE);
+    let mut wlan_ip_addr = String::from(DEFAULT_WLAN_ADDR);
+
     let (state, mut stream) = power_up_and_wait_for_connection(advertise, connect).await?;
+
+    // Get UP interface and IP
+    for ifa in netif::up().unwrap() {
+        match ifa.name() {
+            DEFAULT_WLAN_IFACE => {
+                debug!("Found WLAN interface: {:?}", ifa);
+                // IPv4 Address contains None scope_id, while IPv6 contains Some
+                match ifa.scope_id() { None => {
+                        wlan_ip_addr =  ifa.address().to_string();
+                        break;
+                    }
+                    _ => (),
+                }
+            }
+            _ => (),
+        }
+    }
+
+    // Create a new config from hostapd.conf
+    let hostapd = Config::new()
+        .file(HOSTAPD_FILE)
+        .unwrap();
+
+    // read SSID and WPA_KEY
+    let wlan_ssid = &hostapd.get_str("ssid").unwrap();
+    let wlan_wpa_key = &hostapd.get_str("wpa_passphrase").unwrap();
 
     info!("{} 📲 Sending parameters via bluetooth to phone...", NAME);
     let mut start_req = WifiStartRequest::new();
-    start_req.set_ip_address(String::from(WLAN_IP_ADDR));
+    info!("{} 🛜 Sending Host IP Address: {}", NAME, wlan_ip_addr);
+    start_req.set_ip_address(String::from(wlan_ip_addr));
     start_req.set_port(TCP_SERVER_PORT);
     send_message(&mut stream, stage, MessageId::WifiStartRequest, start_req).await?;
     stage += 1;
@@ -357,9 +388,10 @@ pub async fn bluetooth_setup_connection(
     read_message(&mut stream, stage, MessageId::WifiInfoRequest, started).await?;
 
     let mut info = WifiInfoResponse::new();
-    info.set_ssid(String::from(WLAN_SSID));
-    info.set_key(String::from(WLAN_WPA_KEY));
-    let bssid = mac_address::mac_address_by_name(WLAN_IFACE)
+    info.set_ssid(String::from(wlan_ssid));
+    info.set_key(String::from(wlan_wpa_key));
+    info!("{} 🛜 Sending Host SSID and Password: {}, {}", NAME, wlan_ssid, wlan_wpa_key);
+    let bssid = mac_address::mac_address_by_name(&wlan_iface)
         .unwrap()
         .unwrap()
         .to_string();

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,14 @@ struct Args {
     /// Interval of showing data transfer statistics (0 = disabled)
     #[clap(short, long, value_name = "SECONDS", default_value_t = 0)]
     stats_interval: u16,
+
+    /// UDC Controller name
+    #[clap(
+        short,
+        long
+    )]
+    udc: Option<String>,
+    
 }
 
 fn logging_init(debug: bool, log_path: &PathBuf) {
@@ -106,6 +114,7 @@ async fn tokio_main(
     advertise: bool,
     legacy: bool,
     connect: Option<Address>,
+    udc: Option<String>,
     need_restart: Arc<Notify>,
     tcp_start: Arc<Notify>,
 ) {
@@ -117,7 +126,7 @@ async fn tokio_main(
         std::thread::spawn(|| uevent_listener(accessory_started_cloned));
     }
 
-    let mut usb = UsbGadgetState::new(legacy);
+    let mut usb = UsbGadgetState::new(legacy, udc);
     loop {
         if let Err(e) = usb.init() {
             error!("{} 🔌 USB init error: {}", NAME, e);
@@ -203,6 +212,7 @@ fn main() {
             args.advertise,
             args.legacy,
             args.connect,
+            args.udc,
             need_restart,
             tcp_start,
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,13 @@ struct Args {
         default_value = "wlan0"
     )]
     iface: String,
+
+     /// BLE device name
+    #[clap(
+        short,
+        long
+    )]
+    btalias: Option<String>,
     
 }
 
@@ -120,6 +127,7 @@ fn logging_init(debug: bool, log_path: &PathBuf) {
 
 async fn tokio_main(
     advertise: bool,
+    btalias: Option<String>,
     legacy: bool,
     iface: String,
     connect: Option<Address>,
@@ -143,7 +151,7 @@ async fn tokio_main(
 
         let bt_stop;
         loop {
-            match bluetooth_setup_connection(advertise, &iface, connect, tcp_start.clone()).await {
+            match bluetooth_setup_connection(advertise, btalias.clone(), &iface, connect, tcp_start.clone()).await {
                 Ok(state) => {
                     // we're ready, gracefully shutdown bluetooth in task
                     bt_stop = tokio::spawn(async move { bluetooth_stop(state).await });
@@ -219,6 +227,7 @@ fn main() {
     runtime.spawn(async move {
         tokio_main(
             args.advertise,
+            args.btalias,
             args.legacy,
             args.iface,
             args.connect,

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,14 @@ struct Args {
         long
     )]
     udc: Option<String>,
+
+    /// WLAN / Wi-Fi Hotspot interface
+    #[clap(
+        short,
+        long,
+        default_value = "wlan0"
+    )]
+    iface: String,
     
 }
 
@@ -113,6 +121,7 @@ fn logging_init(debug: bool, log_path: &PathBuf) {
 async fn tokio_main(
     advertise: bool,
     legacy: bool,
+    iface: String,
     connect: Option<Address>,
     udc: Option<String>,
     need_restart: Arc<Notify>,
@@ -134,7 +143,7 @@ async fn tokio_main(
 
         let bt_stop;
         loop {
-            match bluetooth_setup_connection(advertise, connect, tcp_start.clone()).await {
+            match bluetooth_setup_connection(advertise, &iface, connect, tcp_start.clone()).await {
                 Ok(state) => {
                     // we're ready, gracefully shutdown bluetooth in task
                     bt_stop = tokio::spawn(async move { bluetooth_stop(state).await });
@@ -211,6 +220,7 @@ fn main() {
         tokio_main(
             args.advertise,
             args.legacy,
+            args.iface,
             args.connect,
             args.udc,
             need_restart,

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,27 +59,16 @@ struct Args {
     stats_interval: u16,
 
     /// UDC Controller name
-    #[clap(
-        short,
-        long
-    )]
+    #[clap(short, long)]
     udc: Option<String>,
 
     /// WLAN / Wi-Fi Hotspot interface
-    #[clap(
-        short,
-        long,
-        default_value = "wlan0"
-    )]
+    #[clap(short, long, default_value = "wlan0")]
     iface: String,
 
-     /// BLE device name
-    #[clap(
-        short,
-        long
-    )]
+    /// BLE device name
+    #[clap(short, long)]
     btalias: Option<String>,
-    
 }
 
 fn logging_init(debug: bool, log_path: &PathBuf) {
@@ -151,7 +140,15 @@ async fn tokio_main(
 
         let bt_stop;
         loop {
-            match bluetooth_setup_connection(advertise, btalias.clone(), &iface, connect, tcp_start.clone()).await {
+            match bluetooth_setup_connection(
+                advertise,
+                btalias.clone(),
+                &iface,
+                connect,
+                tcp_start.clone(),
+            )
+            .await
+            {
                 Ok(state) => {
                     // we're ready, gracefully shutdown bluetooth in task
                     bt_stop = tokio::spawn(async move { bluetooth_stop(state).await });

--- a/src/usb_gadget.rs
+++ b/src/usb_gadget.rs
@@ -67,7 +67,7 @@ impl UsbGadgetState {
         if let Ok(entries) = fs::read_dir(&udc_dir) {
             for entry in entries {
                 if let Ok(entry) = entry {
-                    debug!("Using UDC: {:?}", entry.file_name());
+                    info!("Using UDC: {:?}", entry.file_name());
                     if let Ok(fname) = entry.file_name().into_string() {
                         state.udc_name.push_str(fname.as_str());
                         break;

--- a/src/usb_gadget.rs
+++ b/src/usb_gadget.rs
@@ -62,7 +62,7 @@ impl UsbGadgetState {
             configfs_path: PathBuf::from("/sys/kernel/config/usb_gadget"),
             udc_name: String::new(),
             legacy,
-            udc
+            udc,
         };
 
         // If UDC argument is passed, use it, otherwise check sys

--- a/src/usb_gadget.rs
+++ b/src/usb_gadget.rs
@@ -72,7 +72,7 @@ impl UsbGadgetState {
                 if let Ok(entries) = fs::read_dir(&udc_dir) {
                     for entry in entries {
                         if let Ok(entry) = entry {
-                            info!("Using UDC: {:?}", entry.file_name());
+                            info!("{} Using UDC: {:?}", NAME, entry.file_name());
                             if let Ok(fname) = entry.file_name().into_string() {
                                 state.udc_name.push_str(fname.as_str());
                                 break;

--- a/src/usb_gadget.rs
+++ b/src/usb_gadget.rs
@@ -53,26 +53,37 @@ pub struct UsbGadgetState {
     configfs_path: PathBuf,
     udc_name: String,
     legacy: bool,
+    udc: Option<String>,
 }
 
 impl UsbGadgetState {
-    pub fn new(legacy: bool) -> UsbGadgetState {
+    pub fn new(legacy: bool, udc: Option<String>) -> UsbGadgetState {
         let mut state = UsbGadgetState {
             configfs_path: PathBuf::from("/sys/kernel/config/usb_gadget"),
             udc_name: String::new(),
             legacy,
+            udc
         };
 
-        let udc_dir = PathBuf::from("/sys/class/udc");
-        if let Ok(entries) = fs::read_dir(&udc_dir) {
-            for entry in entries {
-                if let Ok(entry) = entry {
-                    info!("Using UDC: {:?}", entry.file_name());
-                    if let Ok(fname) = entry.file_name().into_string() {
-                        state.udc_name.push_str(fname.as_str());
-                        break;
+        // If UDC argument is passed, use it, otherwise check sys
+        match state.udc {
+            None => {
+                let udc_dir = PathBuf::from("/sys/class/udc");
+                if let Ok(entries) = fs::read_dir(&udc_dir) {
+                    for entry in entries {
+                        if let Ok(entry) = entry {
+                            info!("Using UDC: {:?}", entry.file_name());
+                            if let Ok(fname) = entry.file_name().into_string() {
+                                state.udc_name.push_str(fname.as_str());
+                                break;
+                            }
+                        }
                     }
                 }
+            }
+            Some(ref udcname) => {
+                info!("Using UDC: {:?}", udcname);
+                state.udc_name.push_str(&udcname);
             }
         }
 


### PR DESCRIPTION
The below patches are complimentary to the awesome work you have done with this repo.

They install:
```
--btalias          Specify the name of the BLE host device
--interface      Specify the interface of the Wi-Fi hotspot
--udc              Specify the UDC controller to use
```

It is an attempt to stop `aa-proxy-rs` and `aawg` from hardcoding a lot of stuff, which should be tunable. Network information is being actively parsed from system. 

Choosing udc controller may be a minor detail, but it's needed if one needs to use `dummy_hcd` as the controller, and it's better to specify than the default "choose the first one" option.

Bear in mind that this is my first time writing anything in Rust/C++, so comments / fixes are welcome. 