### PR TITLE
Add --keepalive argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ OPTIONS:
     -i, --iface <IFACE>
             WLAN / Wi-Fi Hotspot interface [default: wlan0]
 
+    -k, --keepalive
+            Keep alive mode: BLE adapter doesn't turn off after successful connection, so that the
+            phone can remain connected (used in special configurations)
+
     -l, --legacy
             Enable legacy mode
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,11 @@ struct Args {
     /// BLE device name
     #[clap(short, long)]
     btalias: Option<String>,
+
+    /// Keep alive mode: BLE adapter doesn't turn off after successful connection,
+    /// so that the phone can remain connected (used in special configurations)
+    #[clap(short, long)]
+    keepalive: bool,
 }
 
 #[derive(Clone)]
@@ -179,6 +184,7 @@ async fn tokio_main(
     hostapd_conf: PathBuf,
     connect: Option<Address>,
     udc: Option<String>,
+    keepalive: bool,
     need_restart: Arc<Notify>,
     tcp_start: Arc<Notify>,
 ) {
@@ -205,6 +211,7 @@ async fn tokio_main(
                 connect,
                 wifi_conf.clone(),
                 tcp_start.clone(),
+                keepalive,
             )
             .await
             {
@@ -289,6 +296,7 @@ fn main() {
             args.hostapd_conf,
             args.connect,
             args.udc,
+            args.keepalive,
             need_restart,
             tcp_start,
         )


### PR DESCRIPTION
...to maintain BLE adapter connection after successfully launching Android Auto.

This is used in special configurations only. One example is a setup where aa-proxy-rs 
is running on the headunit itself. So the same bluetooth connection is used for music/calls. 

Another example is a a setup where the bluetooth connection needs to be maintained 
in order to keep a Bluetooth PAN interface active. 

Default behavior remains the same. 

I also tried to auto-generate the clap README this time. 