### PR TITLE
Follow-up to #104: fix two serde round-trip asymmetries

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -56,11 +56,21 @@ where
     T::Err: Display,
     D: Deserializer<'de>,
 {
-    let s: Option<String> = Option::deserialize(deserializer)?;
-    match s {
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Repr {
+        Str(String),
+        Int(i64),
+        Float(f64),
+    }
+
+    let v: Option<Repr> = Option::deserialize(deserializer)?;
+    match v {
         None => Ok(None),
-        Some(s) if s.trim().is_empty() => Ok(None),
-        Some(s) => T::from_str(&s).map(Some).map_err(DeError::custom),
+        Some(Repr::Str(s)) if s.trim().is_empty() => Ok(None),
+        Some(Repr::Str(s)) => T::from_str(s.trim()).map(Some).map_err(DeError::custom),
+        Some(Repr::Int(i)) => T::from_str(&i.to_string()).map(Some).map_err(DeError::custom),
+        Some(Repr::Float(f)) => T::from_str(&f.to_string()).map(Some).map_err(DeError::custom),
     }
 }
 

--- a/src/config_types.rs
+++ b/src/config_types.rs
@@ -357,10 +357,19 @@ pub enum HexdumpLevel {
     All,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone)]
 pub struct UsbId {
     pub vid: u16,
     pub pid: u16,
+}
+
+impl Serialize for UsbId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
 }
 
 impl std::str::FromStr for UsbId {


### PR DESCRIPTION
### `Follow-up to` #104: `fix two serde round-trip asymmetries`

Two small server-side fixes for serde asymmetries surfaced by the dashboard after #104 landed. Both follow the same pattern:
serialize emits one JSON shape, deserialize accepts another → round-trip fails.

### `empty_string_as_none`: also accept numbers
Number-typed dashboard inputs send JSON integers (not strings). After #104 the helper accepted `null` and strings but still rejected numbers, so setting e.g. `media_dump_base_port = 12345` failed with `invalid type: integer 12345, expected a string`. Accept string, integer, and float via an internal untagged enum.

### `UsbId`: serialize as `VID:PID` string
`UsbId`'s derived `Serialize` emitted `{"vid":...,"pid":...}`, but `Deserialize` only accepts the `VID:PID` string form (matching `FromStr` / `Display`).
GET returns an object, POST of that object fails. Implement `Serialize` to emit the `Display` form. Also makes `wired = "22b8:0"` display correctly in the dashboard (it was showing `[object Object]` because the text input received the serialized object).
