### PR TITLE
Web input improvements

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -174,15 +174,24 @@
             </div>
           </div>
 
-          <div class="wide-grid">
+          <div class="wide-grid-3">
+            <button type="button" onclick="sendKeyTap(65537, 'MEDIA')">
+              🎵 Media
+            </button>
+            <button type="button" onclick="sendKeyTap(65538, 'NAVIGATION')">
+              🗺️ Nav
+            </button>
+            <button type="button" onclick="sendKeyTap(65539, 'RADIO')">
+              📻 Car radio
+            </button>
+            <button type="button" onclick="sendKeyTap(65540, 'TEL')">
+              🔢 Dialer
+            </button>
             <button type="button" onclick="sendKeyTap(5, 'CALL')">
               📞 Call
             </button>
             <button type="button" onclick="sendKeyTap(6, 'ENDCALL')">
               📴 End Call
-            </button>
-            <button type="button" onclick="sendKeyTap(85, 'MEDIA_PLAY_PAUSE')">
-              ⏯ Play/Pause
             </button>
             <button type="button" onclick="sendKeyTap(127, 'MEDIA_PAUSE')">
               ⏸ Pause
@@ -196,17 +205,20 @@
             <button type="button" onclick="sendKeyTap(88, 'MEDIA_PREVIOUS')">
               ⏮ Previous
             </button>
+            <button type="button" onclick="sendKeyTap(85, 'MEDIA_PLAY_PAUSE')">
+              ⏯ Play/Pause
+            </button>
             <button type="button" onclick="sendKeyTap(87, 'MEDIA_NEXT')">
               ⏭ Next
-            </button>
-            <button type="button" onclick="sendKeyTap(24, 'VOLUME_UP')">
-              🔊 Volume +
             </button>
             <button type="button" onclick="sendKeyTap(25, 'VOLUME_DOWN')">
               🔉 Volume -
             </button>
             <button type="button" onclick="sendKeyTap(164, 'MUTE')">
               🔇 Mute
+            </button>
+            <button type="button" onclick="sendKeyTap(24, 'VOLUME_UP')">
+              🔊 Volume +
             </button>
             <button type="button" onclick="sendKeyTap(4, 'BACK')">
               ↩ Back

--- a/static/index.html
+++ b/static/index.html
@@ -320,6 +320,7 @@
         document.querySelectorAll(".dpad-grid").forEach((dpad) => {
           let angle = 0;
           let pointerId = null;
+          let visual = null;
           
           function onPointerMove(event) {
             if(event.pointerId !== pointerId)
@@ -338,6 +339,7 @@
             if(delta != 0) {
               angle = newAngle;
               sendRotary(delta);
+              visual.style.transform = `rotate(${angle}rad)`;
             }
             
             event.preventDefault();
@@ -347,9 +349,16 @@
             dpad.releasePointerCapture(event.pointerId);
             dpad.style.cursor = "";
             pointerId = null;
+            if(visual) {
+              visual.parentNode.removeChild(visual);
+              visual = null;
+            }
           }
           
           dpad.addEventListener("pointerdown", event => {
+            if(event.target.nodeName.toLowerCase() == "button")
+              return;
+            
             if(pointerId === null) {
               var rect = dpad.getBoundingClientRect();
               var x = event.clientX - rect.left - rect.width / 2;
@@ -360,6 +369,11 @@
               dpad.setPointerCapture(pointerId);
               dpad.style.cursor = "grabbing";
               window.addEventListener("pointermove", onPointerMove, {passive: false});
+              if(!visual) {
+                visual = dpad.appendChild(document.createElement("div"));
+                visual.className = "rotary-visual";
+                visual.style.transform = `rotate(${angle}rad)`;
+              }
             }
             
             event.preventDefault();

--- a/static/index.html
+++ b/static/index.html
@@ -146,12 +146,12 @@
 
             <div>
               <p><strong>D-Pad</strong></p>
-              <div class="dpad-grid">
-                <span></span>
+              <div class="dpad-grid" title="Use scroll wheel or drag corners to send rotary events">
+                <span><span>↻</span></span>
                 <button type="button" onclick="sendKeyTap(19, 'DPAD_UP')">
                   ▲
                 </button>
-                <span></span>
+                <span><span>↺</span></span>
                 <button type="button" onclick="sendKeyTap(21, 'DPAD_LEFT')">
                   ◀
                 </button>
@@ -165,11 +165,11 @@
                 <button type="button" onclick="sendKeyTap(22, 'DPAD_RIGHT')">
                   ▶
                 </button>
-                <span></span>
+                <span><span>↻</span></span>
                 <button type="button" onclick="sendKeyTap(20, 'DPAD_DOWN')">
                   ▼
                 </button>
-                <span></span>
+                <span><span>↺</span></span>
               </div>
             </div>
           </div>
@@ -312,6 +312,67 @@
             fileInput.value = "";
             fileInput.addEventListener("change", handler, { once: true });
             fileInput.click();
+          });
+        });
+
+        // rotary input
+        const STEPS_PER_ROTATION = 8;
+        document.querySelectorAll(".dpad-grid").forEach((dpad) => {
+          let angle = 0;
+          let pointerId = null;
+          
+          function onPointerMove(event) {
+            if(event.pointerId !== pointerId)
+              return;
+            
+            var rect = dpad.getBoundingClientRect();
+            var x = event.clientX - rect.left - rect.width / 2;
+            var y = event.clientY - rect.top - rect.height / 2;
+            var newAngle = Math.atan2(y, x);
+            var delta = ((newAngle - angle) / 2 / Math.PI * STEPS_PER_ROTATION) ^ 0;  // rounds towards 0
+            if(delta > STEPS_PER_ROTATION / 2)
+              delta -= STEPS_PER_ROTATION;
+            if(delta < -STEPS_PER_ROTATION / 2)
+              delta += STEPS_PER_ROTATION;
+            
+            if(delta != 0) {
+              angle = newAngle;
+              sendRotary(delta);
+            }
+            
+            event.preventDefault();
+            return false;
+          }
+          function onPointerUp(event) {
+            dpad.releasePointerCapture(event.pointerId);
+            dpad.style.cursor = "";
+            pointerId = null;
+          }
+          
+          dpad.addEventListener("pointerdown", event => {
+            if(pointerId === null) {
+              var rect = dpad.getBoundingClientRect();
+              var x = event.clientX - rect.left - rect.width / 2;
+              var y = event.clientY - rect.top - rect.height / 2;
+              angle = Math.atan2(y, x);
+              
+              pointerId = event.pointerId;
+              dpad.setPointerCapture(pointerId);
+              dpad.style.cursor = "grabbing";
+              window.addEventListener("pointermove", onPointerMove, {passive: false});
+            }
+            
+            event.preventDefault();
+          }, {passive: false});
+          dpad.addEventListener("pointercancel", onPointerUp);
+          dpad.addEventListener("pointerup", onPointerUp);
+          
+          dpad.addEventListener("wheel", event => {
+            let wheelDelta = event.deltaX != 0 ? event.deltaX : event.deltaY;
+            let delta = wheelDelta > 0 ? 1 : -1;
+            sendRotary(delta);
+            event.preventDefault();
+            return false;
           });
         });
 
@@ -561,6 +622,24 @@
         } catch (error) {
           console.error(`Failed to send key '${label}' (${keycode}):`, error);
           alert(`❌ Failed to send key '${label}' (${keycode}).`);
+        }
+      }
+
+      async function sendRotary(delta) {
+        try {
+          const response = await fetch("/inject_rotary", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ delta }),
+          });
+
+          if (!response.ok) {
+            const body = await response.text();
+            throw new Error(`${response.status}: ${body}`);
+          }
+        } catch (error) {
+          console.error(`Failed to send rotary event '${delta}':`, error);
+          alert(`❌ Failed to send rotary event '${delta}'.`);
         }
       }
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -685,12 +685,15 @@ input[type="checkbox"]:not(.multi-select-dropdown input):checked::after {
     gap: 0.35rem;
     grid-template-columns: repeat(3, minmax(0, 1fr));
     justify-items: stretch;
+    aspect-ratio: 1;
+    cursor: grab;
 }
 
 /* All dpad buttons stretch to fill their grid cell so the arrow keys
    match the width of the phone-keypad buttons next to them. */
 .dpad-grid > button {
     width: 100%;
+    cursor: pointer;
 }
 
 .dpad-center {
@@ -755,7 +758,14 @@ input[type="checkbox"]:not(.multi-select-dropdown input):checked::after {
 
 /* Empty spacers in the dpad grid shouldn't take button visual space. */
 .dpad-grid > span {
+    display: flex;
+    
+    /* for rotary input */
+    touch-action: none;
+}
+.dpad-grid > span > span{
     display: block;
+    margin: auto;
 }
 
 @media (min-width: 900px) {

--- a/static/styles.css
+++ b/static/styles.css
@@ -702,6 +702,14 @@ input[type="checkbox"]:not(.multi-select-dropdown input):checked::after {
     gap: 0.35rem;
     grid-template-columns: repeat(2, minmax(0, 1fr));
 }
+.wide-grid-3 {
+    display: grid;
+    gap: 0.35rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+.controller-drawer-body .wide-grid-3 button {
+    font-size: 0.9rem;
+}
 
 /* Small accent-coloured group label above each keypad / dpad / wide
    grid. Replaces the default <p><strong>…</strong></p> look. */

--- a/static/styles.css
+++ b/static/styles.css
@@ -687,6 +687,19 @@ input[type="checkbox"]:not(.multi-select-dropdown input):checked::after {
     justify-items: stretch;
     aspect-ratio: 1;
     cursor: grab;
+    position: relative;
+}
+.dpad-grid > .rotary-visual {
+    pointer-events: none;
+    touch-action: none;
+    position: absolute;
+    left: -5%;
+    top: -5%;
+    width: 110%;
+    height: 110%;
+    background: radial-gradient(circle at 75% 50%, rgba(18, 31, 58, 0.99) 0%, rgba(10, 12, 18, 0.99) 30%);
+    border-radius: 50%;
+    border: 1px solid rgba(20, 184, 166, 0.2);
 }
 
 /* All dpad buttons stretch to fill their grid cell so the arrow keys


### PR DESCRIPTION
I noticed that a dpad is mostly useless to control AA as it is only used to navigate between regions (like navbar, header bar, content) and navigation within each region is only controllable by rotary inputs. I've implemented a rotary dial emulation to the web interface. Two, actually:

* scrolling with a mouse wheel over the dpad
* dragging one of the corners of the dpad will show a visual knob that can be turned by either mouse or touch input

I've also added a few more keys to the keypad and switched to a 3 column layout.