### PR TITLE
Fix: allow reconnect after manual disconnect

### DIFF
--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -1,5 +1,6 @@
 use crate::btle;
 use crate::config::Action;
+use crate::config::SharedConfig;
 use crate::config::WifiConfig;
 use crate::config::IDENTITY_NAME;
 use crate::config_types::BluetoothAddressList;
@@ -626,7 +627,7 @@ impl Bluetooth {
         if let Some(sess) = hsp_session {
             info!("{} 🎧 Headset Profile (HSP): unregistering ...", NAME);
             drop(sess);
-            tokio::time::sleep(Duration::from_millis(80)).await;
+            tokio::time::sleep(Duration::from_millis(300)).await;
             info!("{} 🎧 Headset Profile (HSP): unregistered", NAME);
         }
     }
@@ -645,6 +646,7 @@ impl Bluetooth {
         mut need_restart: BroadcastReceiver<Option<Action>>,
         restart_tx: BroadcastSender<Option<Action>>,
         profile_connected: Arc<AtomicBool>,
+        shared_config: SharedConfig,
     ) -> Result<()> {
         if bt_poweroff {
             let _ = self.adapter.set_powered(true).await;
@@ -752,6 +754,13 @@ impl Bluetooth {
         // Record this device as a known-good AA device (only when using wildcard connect)
         if is_wildcard_connect {
             save_known_device(address);
+        }
+        // Clear Stop flag here — after BT handshake succeeds but before the proxy loop
+        // is notified. The proxy checks action_requested on every iteration; leaving Stop
+        // set would cause it to kill the session immediately (~20ms).
+        if stopped {
+            info!("{} 🔄 User-stop cleared, phone reconnected manually", NAME);
+            shared_config.write().await.action_requested = None;
         }
         tcp_start.notify_one();
 
@@ -899,7 +908,7 @@ impl Bluetooth {
                 if let Some(sess) = _held_hsp_session {
                     info!("{} 🎧 Headset Profile (HSP): unregistering ...", NAME);
                     drop(sess);
-                    tokio::time::sleep(Duration::from_millis(80)).await;
+                    tokio::time::sleep(Duration::from_millis(300)).await;
                     info!("{} 🎧 Headset Profile (HSP): unregistered", NAME);
                 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -508,11 +508,12 @@ async fn tokio_main(
                             restart_tx.subscribe(),
                             restart_tx.clone(),
                             profile_connected.clone(),
+                            config.clone(),
                         )
                         .await
                     {
                         error!("{} bluetooth AA handshake error: {}", NAME, e);
-                        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
                         continue;
                     }
                 } else {
@@ -541,7 +542,7 @@ async fn tokio_main(
                 "{} 📵 TCP/USB connection closed or not started, trying again...",
                 NAME
             );
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
         } else {
             info!(
                 "{} 📵 TCP/USB connection closed or not started, quick restart...",


### PR DESCRIPTION
When the user taps Disconnect in Android Auto, a Stop flag gets set to block auto-reconnect. The flag was never cleared, so manually clicking the Bluetooth device on the phone would also fail - the BT handshake would complete successfully but the proxy killed the session immediately (~20ms) because it still saw the Stop flag.

Root cause: nothing cleared action_requested after the phone proved it wanted to reconnect by completing the full BT handshake.

Fix: clear the Stop flag inside aa_handshake() right after stage 5 succeeds, before the proxy is notified. The phone has to complete all 5 BT handshake stages to clear it - that's the natural proof of user intent. Also reduced the main loop retry delay from 1s to 200ms, and bumped the HSP unregister sleep from 80ms to 300ms for more reliable profile cleanup on rapid restarts.

Tested on MilkV DuoS with Pixel 8 (Android 16) and Pixel 4a (Android 13).

---

**Before (broken):** disconnect → manual BT tap → handshake succeeds
→ proxy starts → dies in ~20ms → repeat forever

**After:** disconnect → manual BT tap → handshake succeeds → Stop
flag cleared → proxy starts → session runs normally

Log from the fixed version:
```
# User taps Disconnect in Android Auto
[INFO]  mitm/MD:  Disconnect option selected in Android Auto; auto-connect temporarily disabled

# Session ends cleanly (ran for ~28s)
[INFO]  proxy:  ⌛ session time: 27s 926ms
[INFO]  proxy:  💤 waiting for bluetooth handshake...

# Daemon waits — will only accept a manual BT connection from the phone
[INFO]  bluetooth:  ⏳ Waiting for phone to connect via bluetooth...

# ~25 seconds later — user manually taps the Bluetooth device on the phone
[INFO]  bluetooth:  🎧 Headset Profile (HSP): connect from **:**:**:**:**:**
[INFO]  bluetooth:  📱 AA Wireless Profile: connect from **:**:**:**:**:**

# BT handshake runs — all 5 stages
[INFO]  bluetooth:  📨 stage #1 of 5: Sending WifiStartRequest frame to phone...
[INFO]  bluetooth:  📨 stage #2 of 5: Received WifiInfoRequest frame from phone (⏱️ 41 ms)
[INFO]  bluetooth:  📨 stage #3 of 5: Sending WifiInfoResponse frame to phone...
[INFO]  bluetooth:  📨 stage #4 of 5: Received WifiStartResponse frame from phone (⏱️ 9 ms)
[INFO]  bluetooth:  📨 stage #5 of 5: Received WifiConnectStatus frame from phone (⏱️ 1763 ms)

# Handshake complete — Stop flag cleared, proxy is allowed to start
[INFO]  bluetooth:  🔄 User-stop cleared, phone reconnected manually

# Proxy starts and session establishes normally
[INFO]  proxy:  📳 TCP server: new client connected
[INFO]  proxy:  ♾️ Starting to proxy data between HU and MD...
[INFO]  mitm/HU:  🔒 SSL init complete, negotiated cipher: ECDHE-RSA-AES128-GCM-SHA256
[INFO]  mitm/MD:  🔒 SSL init complete, negotiated cipher: ECDHE-RSA-AES128-GCM-SHA256

# All channels open — Android Auto running normally
[INFO]  mitm/HU:  MESSAGE_SERVICE_DISCOVERY_RESPONSE: enabling developer mode
# ... all 8 service channels opened successfully
```