### PR TITLE
contrib: wait for D-Bus socket before starting daemon (BusyBox systems)

### DIFF
--- a/contrib/S93aa-proxy-rs
+++ b/contrib/S93aa-proxy-rs
@@ -13,6 +13,18 @@ RETVAL=0
 
 case "$1" in
 	start)
+		# BusyBox init has no service dependency ordering --
+		# poll until D-Bus socket is ready so aa-proxy-rs can connect on first attempt.
+		echo "Waiting for D-Bus..."
+		DBUS_SOCKET="/var/run/dbus/system_bus_socket"
+		DBUS_WAIT_TRIES=30 # max iterations
+		DBUS_WAIT_INTERVAL=0.1 # seconds per iteration, 3 s total max wait
+		i=0
+		while [ ! -S "$DBUS_SOCKET" ] && [ $i -lt $DBUS_WAIT_TRIES ]; do
+			sleep $DBUS_WAIT_INTERVAL
+			i=$((i + 1))
+		done
+
 		printf "Starting $DAEMON: "
 		start-stop-daemon -S -b -q -m -p "$PIDFILE" -x "/usr/bin/$DAEMON" -- $AA_PROXY_RS_ARGS
 		RETVAL=$?


### PR DESCRIPTION
Adds a short wait loop to `contrib/S93aa-proxy-rs` that polls for the D-Bus socket before launching `aa-proxy-rs`.

On **BusyBox init** systems (MilkV DuoS, Buildroot-based images) there is no service dependency management. `aa-proxy-rs` can start before `dbus-daemon` is ready, fail to connect to Bluetooth, and require a manual restart.

Not an issue on **systemd** - `After=dbus.service` handles this natively.

## Boot log (MilkV DuoS)

```
Waiting for D-Bus...
Starting aa-proxy-rs: OK
1970-01-01, 00:00:29.954 [INFO] 🛸 aa-proxy-rs is starting, build: 20260601_134002
1970-01-01, 00:00:30.028 [INFO] 📱 bluetooth: AA Wireless Profile: registered
1970-01-01, 00:00:30.127 [INFO] 🎧 bluetooth: Headset Profile (HSP): registered
1970-01-01, 00:00:30.128 [INFO] ⏳ bluetooth: Waiting for phone to connect via bluetooth...
```

## Notes

Tested on MilkV DuoS only. On systemd boards this `S*` script is not used. Should be safe on other BusyBox-init boards but not tested.