### PR TITLE
Binary size optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,3 +83,9 @@ protobuf-codegen = "3.7.1"
 [[bin]]
 name = "generate_config"
 path = "src/bin/generate_config.rs"
+
+[profile.release]
+strip = true      # Automatically strips symbols and debug info
+lto = true        # Optional: Enables Link-Time Optimization for even smaller binaries
+codegen-units = 1 # Optional: Reduces parallel code generation, allowing better optimization
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,4 +88,5 @@ path = "src/bin/generate_config.rs"
 strip = true      # Automatically strips symbols and debug info
 lto = true        # Optional: Enables Link-Time Optimization for even smaller binaries
 codegen-units = 1 # Optional: Reduces parallel code generation, allowing better optimization
+panic = "abort"   # Removes unwinding machinery for smaller, slightly faster binaries
 


### PR DESCRIPTION
These changes made my binary size shrink by over 50%.

```
  ┌──────────────────────────────────────────────────┬────────────┬─────────────────────────────┐
  │                     Setting                      │ Build time │         Binary size         │
  ├──────────────────────────────────────────────────┼────────────┼─────────────────────────────┤
  │ Old (default codegen-units=16, no LTO, no strip) │ 2m25s      │ 63,533,360 bytes (~60.6 MB) │
  ├──────────────────────────────────────────────────┼────────────┼─────────────────────────────┤
  │ New (codegen-units=1, LTO, strip)                │ 4m19s      │ 34,015,496 bytes (~32.4 MB) │
  └──────────────────────────────────────────────────┴────────────┴─────────────────────────────┘
  ┌──────────────────────────────────────────┬────────────┬─────────────────────────────┐
  │                 Setting                  │ Build time │         Binary size         │
  ├──────────────────────────────────────────┼────────────┼─────────────────────────────┤
  │ Previous (LTO + codegen-units=1 + strip) │ 4m19s      │ 34,015,496 bytes (~32.4 MB) │
  ├──────────────────────────────────────────┼────────────┼─────────────────────────────┤
  │ + panic = "abort"                        │ 4m58s      │ 30,476,552 bytes (~29.1 MB) │
  └──────────────────────────────────────────┴────────────┴─────────────────────────────┘
  ```