### PR TITLE
Margin/Inset configurator webui

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub mod proxy;
 #[cfg(feature = "wasm-scripting")]
 pub mod script_wasm;
 pub mod sdr_ui;
+pub mod sdr_ui_preview;
 pub mod ssl_rustls;
 pub mod usb_gadget;
 pub mod usb_stream;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1419,6 +1419,33 @@ fn main() -> Result<()> {
 
     // build and spawn main tokio runtime
     let mut runtime = Builder::new_multi_thread().enable_all().build().unwrap();
+
+    // Scheduler-latency probe: one task per worker thread, each ticking
+    // every 200ms. If a tick's actual gap exceeds 1s, something blocked
+    // that worker thread for a while (e.g. a synchronous syscall or
+    // long-running computation on the async runtime). Used to root-cause
+    // the periodic video write-queue-full/resync stalls.
+    let probe_workers = thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
+    for probe_id in 0..probe_workers {
+        runtime.spawn(async move {
+            let mut ticker = tokio::time::interval(Duration::from_millis(200));
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            let mut last = Instant::now();
+            loop {
+                ticker.tick().await;
+                let now = Instant::now();
+                let gap = now.duration_since(last);
+                if gap > Duration::from_secs(1) {
+                    warn!(
+                        "scheduler_probe[{probe_id}]: tick gap {}ms (expected ~200ms) - possible tokio runtime stall",
+                        gap.as_millis()
+                    );
+                }
+                last = now;
+            }
+        });
+    }
+
     let restart_tx_cloned = restart_tx.clone();
     let profile_connected_cloned = profile_connected.clone();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use aa_proxy_rs::mitm::send_byebye;
 use aa_proxy_rs::mitm::OdometerData;
 use aa_proxy_rs::mitm::Packet;
 use aa_proxy_rs::mitm::SharedCompanionIp;
+use aa_proxy_rs::mitm::SharedMediaChannels;
 use aa_proxy_rs::mitm::SharedMediaTapEndpoints;
 use aa_proxy_rs::mitm::SharedServiceDiscoveryResponse;
 use aa_proxy_rs::mitm::TirePressureData;
@@ -37,6 +38,7 @@ use simplelog::*;
 use std::os::unix::fs::PermissionsExt;
 use time::macros::format_description;
 
+use std::collections::HashMap;
 use std::fs;
 use std::fs::OpenOptions;
 use std::path::PathBuf;
@@ -634,6 +636,7 @@ async fn tokio_main(
     last_speed: Arc<RwLock<Option<i32>>>,
     last_service_discovery_response: SharedServiceDiscoveryResponse,
     media_tap_endpoints: SharedMediaTapEndpoints,
+    shared_media_channels: SharedMediaChannels,
     companion_ip: SharedCompanionIp,
     last_tire_pressure_data: Arc<RwLock<Option<TirePressureData>>>,
     led_support: bool,
@@ -657,6 +660,7 @@ async fn tokio_main(
         last_speed,
         last_service_discovery_response,
         media_tap_endpoints,
+        shared_media_channels,
         companion_ip: companion_ip.clone(),
         last_tire_pressure_data,
         ws_event_tx,
@@ -1409,6 +1413,8 @@ fn main() -> Result<()> {
     let last_service_discovery_response_cloned = last_service_discovery_response.clone();
     let media_tap_endpoints: SharedMediaTapEndpoints = Arc::new(RwLock::new(Vec::new()));
     let media_tap_endpoints_cloned = media_tap_endpoints.clone();
+    let shared_media_channels: SharedMediaChannels = Arc::new(Mutex::new(HashMap::new()));
+    let shared_media_channels_cloned = shared_media_channels.clone();
     let companion_ip: SharedCompanionIp = Arc::new(RwLock::new(None));
     let companion_ip_cloned = companion_ip.clone();
     let last_tire_pressure_data = Arc::new(RwLock::new(None));
@@ -1425,7 +1431,9 @@ fn main() -> Result<()> {
     // that worker thread for a while (e.g. a synchronous syscall or
     // long-running computation on the async runtime). Used to root-cause
     // the periodic video write-queue-full/resync stalls.
-    let probe_workers = thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
+    let probe_workers = thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
     for probe_id in 0..probe_workers {
         runtime.spawn(async move {
             let mut ticker = tokio::time::interval(Duration::from_millis(200));
@@ -1486,6 +1494,7 @@ fn main() -> Result<()> {
             last_speed_cloned,
             last_service_discovery_response_cloned,
             media_tap_endpoints_cloned,
+            shared_media_channels_cloned,
             companion_ip_cloned,
             last_tire_pressure_data,
             led_support,
@@ -1518,6 +1527,7 @@ fn main() -> Result<()> {
             usb_connected,
             script_registry.clone(),
             ws_event_tx.clone(),
+            shared_media_channels,
         )
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,11 @@ struct Args {
     /// Generate hostapd config and exit
     #[clap(short = 'o', long)]
     generate_hostapd: bool,
+
+    /// Serve only the web interface (skip USB/Bluetooth/proxy), optionally
+    /// overriding the configured `webserver` bind address
+    #[clap(long, value_name = "BIND_ADDR")]
+    web_only: Option<Option<String>>,
 }
 
 fn configure_kernel_module_path_for_config(cfg: &AppConfig) {
@@ -645,6 +650,7 @@ async fn tokio_main(
     usb_connected: Arc<AtomicBool>,
     ws_event_tx: broadcast::Sender<ServerEvent>,
     script_registry: Option<Arc<ScriptRegistry>>,
+    web_only: bool,
 ) -> Result<()> {
     let accessory_started = Arc::new(Notify::new());
     let accessory_started_cloned = accessory_started.clone();
@@ -730,7 +736,7 @@ async fn tokio_main(
         );
     }
 
-    if cfg.bt_sco {
+    if cfg.bt_sco && !web_only {
         match bt_sco::spawn(BtScoOptions {
             bridge_aa_media_pcm: cfg.bt_sco_media_bridge,
             bridge_ring_capacity: cfg.bt_sco_media_bridge_ring_capacity,
@@ -778,6 +784,14 @@ async fn tokio_main(
                 error!("{} webserver address/port parse: {}", NAME, e);
             }
         }
+    }
+
+    if web_only {
+        info!(
+            "{} 🌐 web-only mode: webserver started, skipping USB/Bluetooth/proxy startup",
+            NAME
+        );
+        return Ok(());
     }
 
     let wifi_config = init_wifi_config(&cfg)
@@ -1254,7 +1268,7 @@ fn main() -> Result<()> {
     let args = Args::parse();
 
     // parse config
-    let config = match AppConfig::load(args.config.clone()) {
+    let mut config = match AppConfig::load(args.config.clone()) {
         Ok(cfg) => cfg,
         Err(e) => {
             eprintln!(
@@ -1266,6 +1280,15 @@ fn main() -> Result<()> {
         }
     };
     let config_json = AppConfig::load_config_json().expect("Invalid embedded config.json");
+
+    let web_only = args.web_only.is_some();
+    if let Some(Some(ref bindaddr)) = args.web_only {
+        config.webserver = Some(bindaddr.clone());
+    }
+    if web_only && config.webserver.is_none() {
+        eprintln!("web-only mode requested but 'webserver' is disabled in config and no bind address was given");
+        std::process::exit(1);
+    }
 
     crash::install_panic_handler(config.crash_dir.clone(), config.crash_handler_enabled);
 
@@ -1378,11 +1401,18 @@ fn main() -> Result<()> {
         );
     }
 
-    if should_prepare_kernel_firmware_path(&config) {
-        configure_kernel_module_path_for_config(&config);
+    if web_only {
+        info!(
+            "{} 🌐 web-only mode: skipping kernel module, network and USB/Bluetooth setup",
+            NAME
+        );
+    } else {
+        if should_prepare_kernel_firmware_path(&config) {
+            configure_kernel_module_path_for_config(&config);
+        }
+        preload_kernel_modules_for_config(&config);
+        bring_external_ap_sta_iface_up_for_config(&config);
     }
-    preload_kernel_modules_for_config(&config);
-    bring_external_ap_sta_iface_up_for_config(&config);
 
     // notify for syncing threads
     let (restart_tx, _) = broadcast::channel(1);
@@ -1503,33 +1533,39 @@ fn main() -> Result<()> {
             usb_connected_cloned,
             ws_event_tx_cloned,
             script_registry_cloned,
+            web_only,
         )
         .await
     });
 
-    // start tokio_uring runtime simultaneously
-    run_io_loop!(
-        runtime,
-        io_loop(
-            restart_tx,
-            tcp_start_cloned,
-            tcp_phone_connected_cloned,
-            tcp_phone_connection_seq_cloned,
-            config,
-            tx,
-            sensor_channel,
-            input_channel,
-            last_battery_data,
-            last_speed,
-            last_service_discovery_response,
-            media_tap_endpoints,
-            companion_ip,
-            usb_connected,
-            script_registry.clone(),
-            ws_event_tx.clone(),
-            shared_media_channels,
-        )
-    );
+    if web_only {
+        // only the webserver task is running; block until a signal exits the process
+        runtime.block_on(std::future::pending::<()>());
+    } else {
+        // start tokio_uring runtime simultaneously
+        run_io_loop!(
+            runtime,
+            io_loop(
+                restart_tx,
+                tcp_start_cloned,
+                tcp_phone_connected_cloned,
+                tcp_phone_connection_seq_cloned,
+                config,
+                tx,
+                sensor_channel,
+                input_channel,
+                last_battery_data,
+                last_speed,
+                last_service_discovery_response,
+                media_tap_endpoints,
+                companion_ip,
+                usb_connected,
+                script_registry.clone(),
+                ws_event_tx.clone(),
+                shared_media_channels,
+            )
+        );
+    }
 
     info!(
         "🚩 aa-proxy-rs terminated, running time: {}",

--- a/src/map_album_art_h264.rs
+++ b/src/map_album_art_h264.rs
@@ -562,7 +562,7 @@ fn throttle_warn(last_warn_at: &mut Option<Instant>, message: &str) {
     }
 }
 
-fn feed_codec_config_to_decoder(
+pub(crate) fn feed_codec_config_to_decoder(
     decoder: &mut Decoder,
     codec_config: &[u8],
 ) -> Result<usize, String> {
@@ -577,7 +577,7 @@ fn feed_codec_config_to_decoder(
     Ok(nal_count)
 }
 
-fn feed_access_unit_to_decoder(
+pub(crate) fn feed_access_unit_to_decoder(
     decoder: &mut Decoder,
     data: &[u8],
 ) -> Result<(Option<Frame>, usize), String> {
@@ -741,7 +741,7 @@ fn percent_size(total: usize, percent: u32) -> Option<usize> {
     }
 }
 
-fn yuv420_pixel_to_rgb(
+pub(crate) fn yuv420_pixel_to_rgb(
     frame: &Frame,
     width: usize,
     height: usize,
@@ -777,7 +777,7 @@ fn clamp_u8(value: i32) -> u8 {
     value.clamp(0, 255) as u8
 }
 
-fn encode_rgb_png(width: u32, height: u32, rgb: &[u8]) -> Result<Vec<u8>, String> {
+pub(crate) fn encode_rgb_png(width: u32, height: u32, rgb: &[u8]) -> Result<Vec<u8>, String> {
     let mut out = Vec::new();
     {
         let mut encoder = png::Encoder::new(&mut out, width, height);

--- a/src/media_tap.rs
+++ b/src/media_tap.rs
@@ -6,12 +6,18 @@ use std::sync::Arc;
 use std::time::Instant;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, mpsc};
 
 use crate::mitm::protos;
 use crate::mitm::protos::{AudioStreamType, DisplayType, MediaCodecType};
 use crate::mitm::{Packet, ProxyType, FRAME_TYPE_FIRST, FRAME_TYPE_LAST, FRAME_TYPE_MASK};
 use crate::mpegts::{MpegTsState, TsStreamKind};
+
+/// Capacity (in queued MPEG-TS write buffers) of the per-client local write
+/// queue. Decouples broadcast consumption from the TCP write to the client,
+/// so a momentarily slow socket write doesn't cause this client to fall
+/// behind on the shared broadcast channel and trigger a full resync.
+const CLIENT_WRITE_QUEUE_CAPACITY: usize = 256;
 
 #[derive(Clone, Copy, Debug)]
 pub struct AudioStreamConfig {
@@ -314,10 +320,23 @@ pub async fn media_tcp_server(port: u16, label: String, sink: MediaSink, _wait_f
                 let label = label.clone();
                 tokio::spawn(async move {
                     let connected_at = Instant::now();
+
+                    // Dedicated writer task: all TCP writes to this client go
+                    // through this queue, so a slow/blocking socket write
+                    // never delays draining the broadcast channel.
+                    let (tx_out, mut rx_out) = mpsc::channel::<Vec<u8>>(CLIENT_WRITE_QUEUE_CAPACITY);
+                    tokio::spawn(async move {
+                        while let Some(buf) = rx_out.recv().await {
+                            if stream.write_all(&buf).await.is_err() {
+                                break;
+                            }
+                        }
+                    });
+
                     let stream_info = {
                         let mut info = sink.get_stream_info().await;
                         if info.is_none() {
-                            let null_pkt = MpegTsState::null_packet();
+                            let null_pkt = MpegTsState::null_packet().to_vec();
                             let mut ticker =
                                 tokio::time::interval(std::time::Duration::from_millis(200));
                             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -325,7 +344,7 @@ pub async fn media_tcp_server(port: u16, label: String, sink: MediaSink, _wait_f
                                 tokio::time::Instant::now() + std::time::Duration::from_secs(30);
                             loop {
                                 ticker.tick().await;
-                                if stream.write_all(&null_pkt).await.is_err() {
+                                if tx_out.send(null_pkt.clone()).await.is_err() {
                                     return;
                                 }
                                 info = sink.get_stream_info().await;
@@ -356,13 +375,14 @@ pub async fn media_tcp_server(port: u16, label: String, sink: MediaSink, _wait_f
                             audio_client_hint(&stream_info, port)
                         );
                         let psi = ts.pat_pmt();
-                        if stream.write_all(&psi).await.is_err() {
+                        if tx_out.send(psi).await.is_err() {
                             return;
                         }
                         let mut rx = sink.subscribe();
                         let mut first_audio_frame_at: Option<Instant> = None;
                         let mut lag_events: u64 = 0;
                         let mut lagged_frames: u64 = 0;
+                        let mut write_lag_events: u64 = 0;
                         let mut psi_ticker =
                             tokio::time::interval(std::time::Duration::from_secs(2));
                         psi_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -392,8 +412,15 @@ pub async fn media_tcp_server(port: u16, label: String, sink: MediaSink, _wait_f
                                                 continue;
                                             };
                                             let pkts = ts.audio_pes(pts_us, &ts_data);
-                                            if stream.write_all(&pkts).await.is_err() {
-                                                break;
+                                            match tx_out.try_send(pkts) {
+                                                Ok(()) => {}
+                                                Err(mpsc::error::TrySendError::Full(_)) => {
+                                                    write_lag_events = write_lag_events.saturating_add(1);
+                                                    warn!(
+                                                        "media_tcp_server: {addr} ({label}) write queue full, dropping audio frame (write_lag_events={write_lag_events})"
+                                                    );
+                                                }
+                                                Err(mpsc::error::TrySendError::Closed(_)) => break,
                                             }
                                         }
                                         Err(broadcast::error::RecvError::Lagged(n)) => {
@@ -410,20 +437,22 @@ pub async fn media_tcp_server(port: u16, label: String, sink: MediaSink, _wait_f
                                 }
                                 _ = psi_ticker.tick() => {
                                     let psi = ts.pat_pmt();
-                                    if stream.write_all(&psi).await.is_err() {
-                                        break;
+                                    match tx_out.try_send(psi) {
+                                        Ok(()) | Err(mpsc::error::TrySendError::Full(_)) => {}
+                                        Err(mpsc::error::TrySendError::Closed(_)) => break,
                                     }
                                 }
                             }
                         }
                         info!(
-                            "media_tcp_server: {addr} ({label}) audio summary: lived={}ms first_frame={}ms lag_events={} lagged_frames={}",
+                            "media_tcp_server: {addr} ({label}) audio summary: lived={}ms first_frame={}ms lag_events={} lagged_frames={} write_lag_events={}",
                             connected_at.elapsed().as_millis(),
                             first_audio_frame_at
                                 .map(|t| t.duration_since(connected_at).as_millis().to_string())
                                 .unwrap_or_else(|| "none".to_string()),
                             lag_events,
-                            lagged_frames
+                            lagged_frames,
+                            write_lag_events
                         );
                         info!("<green>media_tcp_server</>: client disconnected {addr} ({label})");
                         return;
@@ -442,10 +471,11 @@ pub async fn media_tcp_server(port: u16, label: String, sink: MediaSink, _wait_f
                     let mut lagged_frames: u64 = 0;
                     let mut sync_resets: u64 = 0;
                     let mut unsynced_access_units: u64 = 0;
+                    let mut write_lag_events: u64 = 0;
                     let mut missing_codec_cfg_warned = false;
 
                     let initial_psi = ts.pat_pmt();
-                    if stream.write_all(&initial_psi).await.is_err() {
+                    if tx_out.send(initial_psi).await.is_err() {
                         return;
                     }
 
@@ -460,7 +490,7 @@ pub async fn media_tcp_server(port: u16, label: String, sink: MediaSink, _wait_f
                         "media_tcp_server: {addr} ({label}) connected; waiting for first live IDR"
                     );
 
-                    let null_pkt = MpegTsState::null_packet();
+                    let null_pkt = MpegTsState::null_packet().to_vec();
                     let mut null_ticker =
                         tokio::time::interval(std::time::Duration::from_millis(100));
                     null_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -528,12 +558,13 @@ pub async fn media_tcp_server(port: u16, label: String, sink: MediaSink, _wait_f
                                                 }
 
                                                 if synced {
-                                                    if is_idr {
-                                                        let psi = ts.pat_pmt();
-                                                        if stream.write_all(&psi).await.is_err() {
-                                                            break;
-                                                        }
+                                                    let mut out = if is_idr {
+                                                        ts.pat_pmt()
+                                                    } else {
+                                                        Vec::new()
+                                                    };
 
+                                                    if is_idr {
                                                         let idr_payload = if let Some(cfg) = sink.get_codec_cfg().await {
                                                             let mut v =
                                                                 Vec::with_capacity(cfg.len() + access_unit.len());
@@ -549,25 +580,31 @@ pub async fn media_tcp_server(port: u16, label: String, sink: MediaSink, _wait_f
                                                             }
                                                             access_unit
                                                         };
-                                                        let pkts =
-                                                            ts.video_pes(flush_pts_us, &idr_payload, true);
-                                                        if stream.write_all(&pkts).await.is_err() {
-                                                            break;
-                                                        }
+                                                        out.extend_from_slice(&ts.video_pes(flush_pts_us, &idr_payload, true));
                                                     } else {
-                                                        let pkts =
-                                                            ts.video_pes(flush_pts_us, &access_unit, false);
-                                                        if stream.write_all(&pkts).await.is_err() {
-                                                            break;
-                                                        }
+                                                        out = ts.video_pes(flush_pts_us, &access_unit, false);
                                                     }
 
-                                                    if first_output_at.is_none() {
-                                                        first_output_at = Some(Instant::now());
-                                                        info!(
-                                                            "media_tcp_server: {addr} ({label}) first video output after {}ms",
-                                                            connected_at.elapsed().as_millis()
-                                                        );
+                                                    match tx_out.try_send(out) {
+                                                        Ok(()) => {
+                                                            if first_output_at.is_none() {
+                                                                first_output_at = Some(Instant::now());
+                                                                info!(
+                                                                    "media_tcp_server: {addr} ({label}) first video output after {}ms",
+                                                                    connected_at.elapsed().as_millis()
+                                                                );
+                                                            }
+                                                        }
+                                                        Err(mpsc::error::TrySendError::Full(_)) => {
+                                                            write_lag_events = write_lag_events.saturating_add(1);
+                                                            sync_resets = sync_resets.saturating_add(1);
+                                                            warn!(
+                                                                "media_tcp_server: {addr} ({label}) write queue full, dropping frame and re-syncing (write_lag_events={write_lag_events})"
+                                                            );
+                                                            synced = false;
+                                                            ts = MpegTsState::new(); // reset PTS baseline on resync
+                                                        }
+                                                        Err(mpsc::error::TrySendError::Closed(_)) => break,
                                                     }
                                                 }
                                             }
@@ -594,14 +631,15 @@ pub async fn media_tcp_server(port: u16, label: String, sink: MediaSink, _wait_f
                                 }
                             }
                             _ = null_ticker.tick(), if !synced => {
-                                if stream.write_all(&null_pkt).await.is_err() {
-                                    break;
+                                match tx_out.try_send(null_pkt.clone()) {
+                                    Ok(()) | Err(mpsc::error::TrySendError::Full(_)) => {}
+                                    Err(mpsc::error::TrySendError::Closed(_)) => break,
                                 }
                             }
                         }
                     }
                     info!(
-                        "media_tcp_server: {addr} ({label}) video summary: lived={}ms first_frame={}ms first_live_idr={}ms first_output={}ms lag_events={} lagged_frames={} sync_resets={} unsynced_au={} wait_for_live_idr={}",
+                        "media_tcp_server: {addr} ({label}) video summary: lived={}ms first_frame={}ms first_live_idr={}ms first_output={}ms lag_events={} lagged_frames={} write_lag_events={} sync_resets={} unsynced_au={} wait_for_live_idr={}",
                         connected_at.elapsed().as_millis(),
                         first_video_frame_at
                             .map(|t| t.duration_since(connected_at).as_millis().to_string())
@@ -614,6 +652,7 @@ pub async fn media_tcp_server(port: u16, label: String, sink: MediaSink, _wait_f
                             .unwrap_or_else(|| "none".to_string()),
                         lag_events,
                         lagged_frames,
+                        write_lag_events,
                         sync_resets,
                         unsynced_access_units,
                         false

--- a/src/media_tap.rs
+++ b/src/media_tap.rs
@@ -52,6 +52,10 @@ pub struct MediaSink {
     tx: broadcast::Sender<Arc<(u64, Vec<u8>)>>,
     /// Cached codec config frame sent to every new client on connect.
     codec_cfg: Arc<tokio::sync::Mutex<Option<Arc<Vec<u8>>>>>,
+    /// Most recently seen IDR access unit (pts_us, raw Annex-B data), used to
+    /// bootstrap a client straight back into sync after a resync instead of
+    /// waiting for the next naturally-occurring IDR.
+    last_idr: Arc<tokio::sync::Mutex<Option<Arc<(u64, Vec<u8>)>>>>,
     /// Stream metadata learned from ServiceDiscovery.
     stream_info: Arc<tokio::sync::Mutex<Option<MediaStreamInfo>>>,
     /// Monotonic counter bumped each time a TCP client connects to this sink.
@@ -64,6 +68,7 @@ impl MediaSink {
         Self {
             tx,
             codec_cfg: Arc::new(tokio::sync::Mutex::new(None)),
+            last_idr: Arc::new(tokio::sync::Mutex::new(None)),
             stream_info: Arc::new(tokio::sync::Mutex::new(None)),
             client_connect_gen: Arc::new(AtomicU64::new(0)),
         }
@@ -123,6 +128,14 @@ impl MediaSink {
 
     pub async fn get_codec_cfg(&self) -> Option<Arc<Vec<u8>>> {
         self.codec_cfg.lock().await.clone()
+    }
+
+    pub async fn set_last_idr(&self, pts_us: u64, access_unit: Vec<u8>) {
+        *self.last_idr.lock().await = Some(Arc::new((pts_us, access_unit)));
+    }
+
+    pub async fn get_last_idr(&self) -> Option<Arc<(u64, Vec<u8>)>> {
+        self.last_idr.lock().await.clone()
     }
 }
 
@@ -473,6 +486,7 @@ pub async fn media_tcp_server(port: u16, label: String, sink: MediaSink, _wait_f
                     let mut unsynced_access_units: u64 = 0;
                     let mut write_lag_events: u64 = 0;
                     let mut missing_codec_cfg_warned = false;
+                    let mut pending_resync_payload: Option<Vec<u8>> = None;
 
                     let initial_psi = ts.pat_pmt();
                     if tx_out.send(initial_psi).await.is_err() {
@@ -519,12 +533,15 @@ pub async fn media_tcp_server(port: u16, label: String, sink: MediaSink, _wait_f
                                                 let access_unit = std::mem::take(&mut pending_au);
                                                 let is_idr = is_idr_frame(&access_unit);
 
-                                                if is_idr && first_idr_seen_at.is_none() {
-                                                    first_idr_seen_at = Some(Instant::now());
-                                                    info!(
-                                                        "media_tcp_server: {addr} ({label}) first live IDR observed after {}ms",
-                                                        connected_at.elapsed().as_millis()
-                                                    );
+                                                if is_idr {
+                                                    sink.set_last_idr(flush_pts_us, access_unit.clone()).await;
+                                                    if first_idr_seen_at.is_none() {
+                                                        first_idr_seen_at = Some(Instant::now());
+                                                        info!(
+                                                            "media_tcp_server: {addr} ({label}) first live IDR observed after {}ms",
+                                                            connected_at.elapsed().as_millis()
+                                                        );
+                                                    }
                                                 }
 
                                                 if !synced {
@@ -603,6 +620,7 @@ pub async fn media_tcp_server(port: u16, label: String, sink: MediaSink, _wait_f
                                                             );
                                                             synced = false;
                                                             ts = MpegTsState::new(); // reset PTS baseline on resync
+                                                            pending_resync_payload = build_resync_payload(&sink, &mut ts).await;
                                                         }
                                                         Err(mpsc::error::TrySendError::Closed(_)) => break,
                                                     }
@@ -624,6 +642,7 @@ pub async fn media_tcp_server(port: u16, label: String, sink: MediaSink, _wait_f
                                         sync_resets = sync_resets.saturating_add(1);
                                         synced = false;
                                         ts = MpegTsState::new(); // reset PTS baseline on resync
+                                        pending_resync_payload = build_resync_payload(&sink, &mut ts).await;
                                         pending_pts_us = None;
                                         pending_au.clear();
                                     }
@@ -631,9 +650,25 @@ pub async fn media_tcp_server(port: u16, label: String, sink: MediaSink, _wait_f
                                 }
                             }
                             _ = null_ticker.tick(), if !synced => {
-                                match tx_out.try_send(null_pkt.clone()) {
-                                    Ok(()) | Err(mpsc::error::TrySendError::Full(_)) => {}
-                                    Err(mpsc::error::TrySendError::Closed(_)) => break,
+                                if let Some(payload) = pending_resync_payload.take() {
+                                    match tx_out.try_send(payload) {
+                                        Ok(()) => {
+                                            synced = true;
+                                            info!(
+                                                "media_tcp_server: {addr} ({label}) resynced from cached IDR after {}ms",
+                                                connected_at.elapsed().as_millis()
+                                            );
+                                        }
+                                        Err(mpsc::error::TrySendError::Full(payload)) => {
+                                            pending_resync_payload = Some(payload);
+                                        }
+                                        Err(mpsc::error::TrySendError::Closed(_)) => break,
+                                    }
+                                } else {
+                                    match tx_out.try_send(null_pkt.clone()) {
+                                        Ok(()) | Err(mpsc::error::TrySendError::Full(_)) => {}
+                                        Err(mpsc::error::TrySendError::Closed(_)) => break,
+                                    }
                                 }
                             }
                         }
@@ -665,6 +700,26 @@ pub async fn media_tcp_server(port: u16, label: String, sink: MediaSink, _wait_f
             }
         }
     }
+}
+
+/// Build a PAT/PMT + codec_cfg + IDR payload from the sink's cached IDR, to
+/// bootstrap a resyncing client back into sync immediately instead of
+/// waiting for the next naturally-occurring IDR. Returns `None` if no IDR
+/// has been cached yet (e.g. before the first live IDR on this sink).
+async fn build_resync_payload(sink: &MediaSink, ts: &mut MpegTsState) -> Option<Vec<u8>> {
+    let cached = sink.get_last_idr().await?;
+    let (pts_us, ref au) = *cached;
+    let mut out = ts.pat_pmt();
+    let payload = if let Some(cfg) = sink.get_codec_cfg().await {
+        let mut v = Vec::with_capacity(cfg.len() + au.len());
+        v.extend_from_slice(&cfg);
+        v.extend_from_slice(au);
+        v
+    } else {
+        au.clone()
+    };
+    out.extend_from_slice(&ts.video_pes(pts_us, &payload, true));
+    Some(out)
 }
 
 /// Scan all NAL units in an Annex-B buffer looking for IDR (type 5).

--- a/src/media_tap.rs
+++ b/src/media_tap.rs
@@ -3,7 +3,7 @@ use simplelog::*;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
 use tokio::sync::{broadcast, mpsc};
@@ -338,10 +338,21 @@ pub async fn media_tcp_server(port: u16, label: String, sink: MediaSink, _wait_f
                     // through this queue, so a slow/blocking socket write
                     // never delays draining the broadcast channel.
                     let (tx_out, mut rx_out) = mpsc::channel::<Vec<u8>>(CLIENT_WRITE_QUEUE_CAPACITY);
+                    let writer_addr = addr;
+                    let writer_label = label.clone();
                     tokio::spawn(async move {
                         while let Some(buf) = rx_out.recv().await {
+                            let write_started = Instant::now();
                             if stream.write_all(&buf).await.is_err() {
                                 break;
+                            }
+                            let write_elapsed = write_started.elapsed();
+                            if write_elapsed > Duration::from_millis(250) {
+                                warn!(
+                                    "media_tcp_server: {writer_addr} ({writer_label}) write_all took {}ms ({} bytes) - client read side may be stalled",
+                                    write_elapsed.as_millis(),
+                                    buf.len()
+                                );
                             }
                         }
                     });

--- a/src/media_tap.rs
+++ b/src/media_tap.rs
@@ -1,7 +1,7 @@
 use protobuf::Enum;
 use simplelog::*;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::io::AsyncWriteExt;
@@ -44,6 +44,43 @@ pub struct MediaStreamInfo {
     pub audio_config: Option<AudioStreamConfig>,
 }
 
+/// Window of access units captured starting at an IDR, used to decode a
+/// representative still frame for the margins-panel preview. A lone IDR only
+/// shows whatever was on screen at that exact keyframe moment; capturing a
+/// short *contiguous* run of frames after it (cheap -- just buffering raw
+/// bytes, no decode) lets the preview decode a temporally coherent sequence
+/// up to a couple of seconds past the keyframe instead. We deliberately don't
+/// try to splice in arbitrary *later* live frames: P-frames only decode
+/// correctly as an unbroken chain from their reference frame, so skipping
+/// ahead to "now" without decoding everything in between would produce
+/// corrupted output, not a fresher one.
+struct IdrBurst {
+    /// When the IDR that started this burst was cached (wall clock), so the
+    /// preview can report how old the resulting frame actually is.
+    cached_at: Instant,
+    /// `(pts_us, raw Annex-B access unit)`, oldest (the IDR) first.
+    units: Vec<(u64, Vec<u8>)>,
+    /// This burst's own target capture duration -- wider for the first IDR of
+    /// a session (to outlast AA's loading screen after projection starts),
+    /// negligible for subsequent ones (steady-state IDRs already show real
+    /// content, so there's no loading screen to skip past).
+    window: Duration,
+}
+
+/// Capture window for the first IDR a sink ever sees -- wide enough to
+/// outlast AA's post-launch loading screen. Main display gets a bit more
+/// than other displays (tuned empirically).
+const IDR_BURST_FIRST_WINDOW_MAIN: Duration = Duration::from_secs(4);
+const IDR_BURST_FIRST_WINDOW_OTHER: Duration = Duration::from_secs(3);
+/// Capture window for every subsequent IDR on the same sink. Steady-state
+/// IDRs (periodic refresh, resync) already show real content, so just the
+/// bare IDR is enough -- effectively zero extra frames.
+const IDR_BURST_STEADY_WINDOW: Duration = Duration::ZERO;
+/// Hard cap on unit count as a defensive bound (e.g. against an unexpectedly
+/// high frame rate), sized with margin above the largest first-IDR window
+/// (60fps * window) so it doesn't silently truncate the window first.
+const IDR_BURST_MAX_UNITS: usize = 260;
+
 /// Broadcast-based sink for tapping a single media channel over TCP.
 #[derive(Clone)]
 pub struct MediaSink {
@@ -56,6 +93,12 @@ pub struct MediaSink {
     /// bootstrap a client straight back into sync after a resync instead of
     /// waiting for the next naturally-occurring IDR.
     last_idr: Arc<tokio::sync::Mutex<Option<Arc<(u64, Vec<u8>)>>>>,
+    /// Short contiguous run of access units starting at the last IDR, for the
+    /// margins-panel preview. See [`IdrBurst`].
+    idr_burst: Arc<tokio::sync::Mutex<Option<IdrBurst>>>,
+    /// Whether this sink has cached an IDR before, so [`set_last_idr`](Self::set_last_idr)
+    /// knows whether to use the wide first-IDR window or the steady-state one.
+    seen_first_idr: Arc<AtomicBool>,
     /// Stream metadata learned from ServiceDiscovery.
     stream_info: Arc<tokio::sync::Mutex<Option<MediaStreamInfo>>>,
     /// Monotonic counter bumped each time a TCP client connects to this sink.
@@ -69,6 +112,8 @@ impl MediaSink {
             tx,
             codec_cfg: Arc::new(tokio::sync::Mutex::new(None)),
             last_idr: Arc::new(tokio::sync::Mutex::new(None)),
+            idr_burst: Arc::new(tokio::sync::Mutex::new(None)),
+            seen_first_idr: Arc::new(AtomicBool::new(false)),
             stream_info: Arc::new(tokio::sync::Mutex::new(None)),
             client_connect_gen: Arc::new(AtomicU64::new(0)),
         }
@@ -130,12 +175,101 @@ impl MediaSink {
         self.codec_cfg.lock().await.clone()
     }
 
-    pub async fn set_last_idr(&self, pts_us: u64, access_unit: Vec<u8>) {
-        *self.last_idr.lock().await = Some(Arc::new((pts_us, access_unit)));
+    /// Caches the IDR for resync bootstrapping and starts a fresh
+    /// [`IdrBurst`] for the margins-panel preview. Returns whether this was
+    /// treated as the sink's first IDR (wide window) or a steady-state one
+    /// (bare IDR only) -- callers should log this with their own channel
+    /// context, since MediaSink itself doesn't know its channel/offset.
+    pub async fn set_last_idr(&self, pts_us: u64, access_unit: Vec<u8>) -> bool {
+        *self.last_idr.lock().await = Some(Arc::new((pts_us, access_unit.clone())));
+        let is_first = !self.seen_first_idr.swap(true, Ordering::Relaxed);
+        let window = if is_first {
+            let is_main = matches!(
+                self.get_stream_info().await,
+                Some(MediaStreamInfo {
+                    kind: MediaStreamKind::Video {
+                        display_type: DisplayType::DISPLAY_TYPE_MAIN,
+                        ..
+                    },
+                    ..
+                })
+            );
+            if is_main {
+                IDR_BURST_FIRST_WINDOW_MAIN
+            } else {
+                IDR_BURST_FIRST_WINDOW_OTHER
+            }
+        } else {
+            IDR_BURST_STEADY_WINDOW
+        };
+        *self.idr_burst.lock().await = Some(IdrBurst {
+            cached_at: Instant::now(),
+            units: vec![(pts_us, access_unit)],
+            window,
+        });
+        is_first
     }
 
     pub async fn get_last_idr(&self) -> Option<Arc<(u64, Vec<u8>)>> {
         self.last_idr.lock().await.clone()
+    }
+
+    /// Appends a non-IDR access unit to the current burst (if any, and if
+    /// still within that burst's window/count cap). No-op once the cap is
+    /// hit, or if no IDR has started a burst yet. Returns the resulting
+    /// burst length only when an append actually happened (i.e. only when
+    /// the length just changed), so callers can log on change without
+    /// tracking previous-length state themselves; returns `None` for a
+    /// no-op (window/cap already exceeded, or no burst at all).
+    pub async fn append_to_idr_burst(&self, pts_us: u64, access_unit: Vec<u8>) -> Option<usize> {
+        let mut guard = self.idr_burst.lock().await;
+        let burst = guard.as_mut()?;
+        if burst.cached_at.elapsed() < burst.window && burst.units.len() < IDR_BURST_MAX_UNITS {
+            burst.units.push((pts_us, access_unit));
+            Some(burst.units.len())
+        } else {
+            None
+        }
+    }
+
+    /// Returns the current burst's access units (IDR first) and how long ago
+    /// that IDR was cached, for the margins-panel preview to decode and
+    /// report an honest age alongside.
+    pub async fn get_idr_burst(&self) -> Option<(Instant, Vec<(u64, Vec<u8>)>)> {
+        self.idr_burst
+            .lock()
+            .await
+            .as_ref()
+            .map(|b| (b.cached_at, b.units.clone()))
+    }
+
+    /// Cheap identity for the current burst's content -- the IDR's pts plus
+    /// the current unit count, which changes whenever the burst grows --
+    /// without cloning the (potentially large) access unit bytes. Lets a
+    /// caller build an ETag and skip a full decode entirely via a
+    /// conditional (If-None-Match) request when the burst hasn't changed.
+    pub async fn get_idr_burst_version(&self) -> Option<(u64, usize)> {
+        let guard = self.idr_burst.lock().await;
+        let burst = guard.as_ref()?;
+        let first_pts = burst.units.first().map(|(pts, _)| *pts).unwrap_or(0);
+        Some((first_pts, burst.units.len()))
+    }
+
+    /// Marks this sink as not having seen an IDR yet, so the *next* one is
+    /// treated as a fresh session's first IDR (wide burst window) rather than
+    /// a steady-state one (bare IDR only).
+    ///
+    /// Needed because the offset-keyed sink registry this is created through
+    /// (`media_sinks` in mitm.rs) deliberately persists across reconnects --
+    /// it's the same MediaSink object, `seen_first_idr` included, every time.
+    /// Without resetting it here, a channel's *actual* first IDR after a
+    /// reconnect gets treated as a steady-state one (since the flag was
+    /// already flipped true by an earlier session), and the preview goes
+    /// back to showing AA's loading screen/black with no extra frames to
+    /// outlast it. Call this whenever a sink is reused for a new connection,
+    /// not on every lookup within the same session.
+    pub fn reset_for_new_session(&self) {
+        self.seen_first_idr.store(false, Ordering::Relaxed);
     }
 }
 
@@ -337,7 +471,8 @@ pub async fn media_tcp_server(port: u16, label: String, sink: MediaSink, _wait_f
                     // Dedicated writer task: all TCP writes to this client go
                     // through this queue, so a slow/blocking socket write
                     // never delays draining the broadcast channel.
-                    let (tx_out, mut rx_out) = mpsc::channel::<Vec<u8>>(CLIENT_WRITE_QUEUE_CAPACITY);
+                    let (tx_out, mut rx_out) =
+                        mpsc::channel::<Vec<u8>>(CLIENT_WRITE_QUEUE_CAPACITY);
                     let writer_addr = addr;
                     let writer_label = label.clone();
                     tokio::spawn(async move {
@@ -545,7 +680,16 @@ pub async fn media_tcp_server(port: u16, label: String, sink: MediaSink, _wait_f
                                                 let is_idr = is_idr_frame(&access_unit);
 
                                                 if is_idr {
-                                                    sink.set_last_idr(flush_pts_us, access_unit.clone()).await;
+                                                    // Do not call sink.set_last_idr() here: the producer side
+                                                    // (tap_media_message) already caches every IDR
+                                                    // unconditionally as it taps the raw packet stream. Calling
+                                                    // it again here for the same IDR (just observed a few ms
+                                                    // later, via this client's own broadcast subscription)
+                                                    // would see seen_first_idr already true and wrongly
+                                                    // downgrade an in-progress wide-window burst to the
+                                                    // zero-window steady-state, freezing it at just the bare
+                                                    // IDR -- exactly the bug seen on channels with a tap
+                                                    // client connected (this loop only runs for one).
                                                     if first_idr_seen_at.is_none() {
                                                         first_idr_seen_at = Some(Instant::now());
                                                         info!(
@@ -920,6 +1064,22 @@ pub(crate) async fn tap_media_message(
                             media_data.len(),
                             &media_data[..media_data.len().min(16)]
                         );
+                        // Cache unconditionally at the producer side (the existing
+                        // cache in media_tcp_server's per-client resync loop only
+                        // updates once a tap client has connected and subscribed) so
+                        // a still-frame preview is available for any channel that is
+                        // actively streaming, even with no tap client ever attached.
+                        let is_first_idr = sink.set_last_idr(pts_us, media_data.to_vec()).await;
+                        info!(
+                            "{} <blue>media tap:</> IDR cached on ch {:#04x}, burst={}",
+                            tap_name(proxy_type),
+                            pkt.channel,
+                            if is_first_idr {
+                                "FIRST (wide window)"
+                            } else {
+                                "steady-state (bare IDR)"
+                            }
+                        );
                     } else {
                         debug!(
                             "{} media tap DATA ch {:#04x}: pts={}us, {}b, first: {:02X?}",
@@ -929,6 +1089,19 @@ pub(crate) async fn tap_media_message(
                             media_data.len(),
                             &media_data[..media_data.len().min(8)]
                         );
+                        // Extend the current burst (if any) so the margins-panel
+                        // preview can decode a short coherent run past the
+                        // keyframe instead of just the bare IDR.
+                        if let Some(burst_len) =
+                            sink.append_to_idr_burst(pts_us, media_data.to_vec()).await
+                        {
+                            debug!(
+                                "{} media tap: ch {:#04x} burst now {} unit(s)",
+                                tap_name(proxy_type),
+                                pkt.channel,
+                                burst_len
+                            );
+                        }
                     }
                     sink.send_frame(pts_us, media_data.to_vec()).await;
                 }

--- a/src/mitm.rs
+++ b/src/mitm.rs
@@ -2639,6 +2639,36 @@ pub async fn pkt_modify_hook(
 
                 if tap_media {
                     if let Some(sink) = media_sink_for_channel(ctx, pkt.channel).await {
+                        // If video focus on this channel just came back to PROJECTED
+                        // (HU-initiated via VideoFocusRequest, or the phone's own
+                        // unsolicited indication), the phone is about to restart its
+                        // encoder for this channel -- the same "fresh start" as a
+                        // reconnect, just without one. Without this, a focus toggle
+                        // produces the exact bug a reconnect used to: the next IDR
+                        // gets treated as steady-state (seen_first_idr already true
+                        // from earlier in this same session) and the preview is left
+                        // with a single bare IDR -- often a black/loading frame.
+                        let focus_msg_id = frame_data
+                            .get(0..2)
+                            .map(|b| u16::from_be_bytes([b[0], b[1]]));
+                        if focus_msg_id == Some(MEDIA_MESSAGE_VIDEO_FOCUS_NOTIFICATION as u16) {
+                            if let Ok(notif) =
+                                VideoFocusNotification::parse_from_bytes(&frame_data[2..])
+                            {
+                                if matches!(
+                                    notif.focus(),
+                                    VideoFocusMode::VIDEO_FOCUS_PROJECTED
+                                        | VideoFocusMode::VIDEO_FOCUS_PROJECTED_NO_INPUT_FOCUS
+                                ) {
+                                    sink.reset_for_new_session();
+                                    info!(
+                                        "{} media tap: ch {:#04x} video focus -> PROJECTED; next IDR treated as fresh session start",
+                                        get_name(proxy_type),
+                                        pkt.channel
+                                    );
+                                }
+                            }
+                        }
                         tap_media_message(proxy_type, pkt, &sink, &frame_data).await;
                     } else {
                         debug!(

--- a/src/mitm.rs
+++ b/src/mitm.rs
@@ -400,6 +400,17 @@ async fn get_or_create_media_sink_for_offset(
 
     let mut media_sinks = ctx.media_sinks.lock().await;
     if let Some(sink) = media_sinks.get(&offset).cloned() {
+        // This registry persists across reconnects by design (it's created
+        // once in io_loop, before the reconnect loop), so the same sink --
+        // and its seen_first_idr flag -- would otherwise carry over from a
+        // previous session. This function is only called once per offset
+        // per SDR processing event (i.e. once per connection), so resetting
+        // here correctly means "once per new session", not "every lookup".
+        info!(
+            "media tap: reusing sink for offset {} ({}); reset seen_first_idr for new session",
+            offset, label
+        );
+        sink.reset_for_new_session();
         return Some(sink);
     }
 
@@ -412,6 +423,10 @@ async fn get_or_create_media_sink_for_offset(
         return None;
     };
 
+    info!(
+        "media tap: creating new sink for offset {} ({}); seen_first_idr starts false",
+        offset, label
+    );
     let sink = MediaSink::new(128);
     tokio::spawn(media_tcp_server(
         port,
@@ -3678,6 +3693,37 @@ pub async fn send_byebye(tx: Sender<Packet>) -> Result<()> {
     };
     tx.send(pkt).await?;
     info!("mitm: Sending ByeByeRequest (USER_SELECTION) to phone...");
+    Ok(())
+}
+
+/// Pushes a runtime margin/inset update to the phone on an active video channel,
+/// via UpdateUiConfigRequest (wire ID 0x800A, HU->Phone). This is the same message
+/// type used inbound at 0x8009 (Phone->HU) -- only the wire ID differs by direction.
+/// Fire-and-forget: the phone does not reply to this message.
+pub async fn send_ui_config_update(
+    tx: Sender<Packet>,
+    video_ch: u8,
+    config: AdditionalVideoConfig,
+) -> Result<()> {
+    let mut req = UpdateUiConfigRequest::new();
+    req.config = Some(config).into();
+
+    let mut payload = req.write_to_bytes()?;
+    let msg_id = MediaMessageId::MEDIA_MESSAGE_UPDATE_UI_CONFIG_REPLY as u16; // 0x800A outbound
+    payload.insert(0, (msg_id >> 8) as u8);
+    payload.insert(1, (msg_id & 0xff) as u8);
+
+    let pkt = Packet {
+        channel: video_ch,
+        flags: ENCRYPTED | FRAME_TYPE_FIRST | FRAME_TYPE_LAST,
+        final_length: None,
+        payload,
+    };
+    tx.send(pkt).await?;
+    info!(
+        "mitm/web: pushed live UI config update on video channel {:#04x}",
+        video_ch
+    );
     Ok(())
 }
 

--- a/src/protos/protos.proto
+++ b/src/protos/protos.proto
@@ -139,6 +139,57 @@ message Insets {
   optional uint32 right = 4;
 }
 
+// Real wire schema for VideoConfiguration field 11 / UpdateUiConfigRequest field 1
+// (APK class wcb/wcm), per open-android-auto deep-trace verification. Distinct
+// from the legacy UiConfig above: fields 1-3 are resolution ranges, not insets;
+// margins/insets live in margin_configs (field 7).
+message AdditionalVideoConfig {
+  optional VideoResolutionRange min_resolution = 1;
+  optional VideoResolutionRange max_resolution = 2;
+  optional VideoResolutionRange preferred_resolution = 3;
+  optional UiTheme ui_theme = 4;
+  repeated UIElement hidden_ui_elements = 5;
+  repeated VideoResizeAction resize_actions = 6;
+  repeated VideoMarginConfig margin_configs = 7;
+}
+
+message VideoResolutionRange {
+  optional uint32 width = 1;
+  optional uint32 height = 2;
+  optional uint32 density = 3;
+  optional uint32 fps = 4;
+}
+
+enum UIElement {
+  UI_ELEMENT_UNKNOWN = 0;
+  UI_ELEMENT_CLOCK = 1;
+  UI_ELEMENT_BATTERY_LEVEL = 2;
+  UI_ELEMENT_PHONE_SIGNAL = 3;
+  UI_ELEMENT_NATIVE_UI_AFFORDANCE = 4;
+  UI_ELEMENT_NAVIGATION_TURN_DATA_AVAILABLE = 5;
+}
+
+enum ResizeActionType {
+  ACTION_UNKNOWN = 0;
+  ACTION_RESIZE_TO_SMALLER = 1;
+  ACTION_RESIZE_TO_LARGER = 2;
+}
+
+message VideoResizeAction {
+  optional ResizeActionType action = 1;
+}
+
+message VideoMarginConfig {
+  optional VideoInsets insets = 1;
+}
+
+message VideoInsets {
+  optional uint32 left = 1;
+  optional uint32 top = 2;
+  optional uint32 right = 3;
+  optional uint32 bottom = 4;
+}
+
 message MediaSourceService {
   optional MediaCodecType available_type = 1
       [ default = MEDIA_CODEC_AUDIO_PCM ];
@@ -480,7 +531,11 @@ message VideoFocusNotification {
   optional bool unsolicited = 2;
 }
 
-message UpdateUiConfigRequest { optional UiConfig ui_config = 1; }
+// Bidirectional runtime UI config push (APK class wci). Wire ID is 0x8009
+// inbound (Phone->HU) and 0x800A outbound (HU->Phone) -- same message, same
+// schema, direction-dependent ID. Field 1 is required by the phone; missing
+// it triggers PROTOCOL_WRONG_MESSAGE / INVALID_UI_CONFIG.
+message UpdateUiConfigRequest { optional AdditionalVideoConfig config = 1; }
 
 message UpdateUiConfigReply { optional UiConfig ui_config = 1; }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -664,6 +664,7 @@ pub async fn io_loop(
     usb_connected: Arc<AtomicBool>,
     script_registry: Option<Arc<ScriptRegistry>>,
     ws_event_tx: BroadcastSender<ServerEvent>,
+    shared_media_channels: SharedMediaChannels,
 ) -> Result<()> {
     let shared_config = config.clone();
     #[allow(unused_variables)]
@@ -704,7 +705,9 @@ pub async fn io_loop(
         startup_aux_tap_slots,
     )
     .await;
-    let persistent_media_channels: SharedMediaChannels = Arc::new(Mutex::new(HashMap::new()));
+    // Shared with AppState (see web::AppState::shared_media_channels) so the web UI
+    // can pull a still frame from a channel's cached IDR for the margins preview.
+    let persistent_media_channels: SharedMediaChannels = shared_media_channels;
 
     loop {
         // reload new config

--- a/src/script_wasm.rs
+++ b/src/script_wasm.rs
@@ -85,30 +85,48 @@ pub fn start_wasm_engine(
     let script_registry_for_watch = script_registry.clone();
     let hook_dir_for_watch = hook_dir.clone();
     runtime.spawn(async move {
+        let _wasm_watcher = wasm_watcher;
         while let Some(res) = watch_rx.recv().await {
-            match res {
-                Ok(event) => match event.kind {
-                    EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_) => {
-                        let old_scripts = script_registry_for_watch.reload_dir(&hook_dir_for_watch);
-                        destroy_loaded_scripts(old_scripts).await;
-
-                        let errs: Vec<(std::path::PathBuf, String)> =
-                            script_registry_for_watch.list_errors();
-                        for (path, err) in errs {
-                            error!("[wasm] script load error [{}]: {}", path.display(), err);
-                        }
-
-                        info!(
-                            "[wasm] loaded wasm script count={}",
-                            script_registry_for_watch.list_scripts().len()
-                        );
-                    }
-                    _ => {}
-                },
+            let triggered = match res {
+                Ok(event) => matches!(
+                    event.kind,
+                    EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+                ) && (event.paths.is_empty()
+                    || event.paths.iter().any(|p| {
+                        p.extension().map(|e| e == "wasm").unwrap_or(false)
+                    })),
                 Err(err) => {
                     error!("[wasm] watcher error: {}", err);
+                    false
                 }
+            };
+
+            if !triggered {
+                continue;
             }
+
+            // Drain any further events that arrive within the debounce window so
+            // a multi-write transfer (e.g. scp) only causes a single reload.
+            while let Ok(Some(_)) = tokio::time::timeout(
+                Duration::from_millis(WASM_RELOAD_DEBOUNCE_MS),
+                watch_rx.recv(),
+            )
+            .await
+            {}
+
+            let old_scripts = script_registry_for_watch.reload_dir(&hook_dir_for_watch);
+            destroy_loaded_scripts(old_scripts).await;
+
+            let errs: Vec<(std::path::PathBuf, String)> =
+                script_registry_for_watch.list_errors();
+            for (path, err) in errs {
+                error!("[wasm] script load error [{}]: {}", path.display(), err);
+            }
+
+            info!(
+                "[wasm] loaded wasm script count={}",
+                script_registry_for_watch.list_scripts().len()
+            );
         }
     });
 
@@ -143,6 +161,7 @@ impl ScriptEffects {
 }
 
 const WASM_EPOCH_TICK_INTERVAL_MS: u64 = 10;
+const WASM_RELOAD_DEBOUNCE_MS: u64 = 500;
 
 #[derive(Clone, Copy, Debug)]
 struct EffectiveScriptLimits {

--- a/src/sdr_ui.rs
+++ b/src/sdr_ui.rs
@@ -1,7 +1,9 @@
 use crate::config::AppConfig;
 use crate::mitm::protos::{
-    DisplayType, Insets, ServiceDiscoveryResponse, UiConfig, VideoConfiguration,
+    AdditionalVideoConfig, DisplayType, Insets, ServiceDiscoveryResponse, UiConfig,
+    VideoConfiguration, VideoInsets, VideoMarginConfig,
 };
+use crate::mitm::Packet;
 use anyhow::{anyhow, Context, Result};
 use chrono::Local;
 use serde::{Deserialize, Serialize};
@@ -10,6 +12,7 @@ use simplelog::*;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+use tokio::sync::mpsc::Sender;
 
 const NAME: &str = "<i><bright-black> sdr-ui: </>";
 const HASH_LEN: usize = 12;
@@ -805,6 +808,186 @@ fn keep_insets_inside_resolution(
     }
 }
 
+/// Pushes a freshly saved vehicle profile's margin overrides to a currently
+/// connected phone, if any, so margin/inset changes take effect immediately
+/// instead of requiring a reconnect. Returns the number of video channels
+/// updated.
+pub async fn push_live_margin_updates(
+    tx: Sender<Packet>,
+    vehicle_profile: &SdrUiVehicleProfile,
+) -> usize {
+    let phone = current_phone();
+    let updates = resolve_live_margin_updates(vehicle_profile, phone.as_ref());
+    let mut pushed = 0usize;
+    for (channel, config) in updates {
+        match crate::mitm::send_ui_config_update(tx.clone(), channel, config).await {
+            Ok(()) => pushed += 1,
+            Err(e) => warn!(
+                "{} failed to push live UI config update on channel {:#04x}: {:#}",
+                NAME, channel, e
+            ),
+        }
+    }
+    if pushed > 0 {
+        info!(
+            "{} pushed live margin update(s) to {} video channel(s) for vehicle=<b>{}</>",
+            NAME, pushed, vehicle_profile.id
+        );
+    }
+    pushed
+}
+
+/// Computes the runtime margin push payloads needed to apply a freshly saved
+/// profile to a phone already connected, without requiring a reconnect.
+/// Only displays/video configs whose profile sets `margins` are included --
+/// content_insets/stable_content_insets have no equivalent in the verified
+/// runtime wire schema (AdditionalVideoConfig only carries margin_configs).
+fn resolve_live_margin_updates(
+    vehicle_profile: &SdrUiVehicleProfile,
+    phone: Option<&PhoneIdentity>,
+) -> Vec<(u8, AdditionalVideoConfig)> {
+    let Some(current) = current_sdr_ui() else {
+        return Vec::new();
+    };
+    if current.vehicle_id != vehicle_profile.id || !vehicle_profile.enabled {
+        return Vec::new();
+    }
+
+    let phone_profile = phone.and_then(|p| {
+        vehicle_profile
+            .phones
+            .iter()
+            .find(|ph| ph.id == p.id && ph.enabled)
+    });
+
+    let mut updates = Vec::new();
+
+    for live_display in &current.displays {
+        let Some(service_id) = live_display.service_id else {
+            continue;
+        };
+        let Ok(channel) = u8::try_from(service_id) else {
+            continue;
+        };
+
+        let vehicle_display = vehicle_profile.displays.iter().find(|d| {
+            display_matches(
+                d,
+                live_display.service_id,
+                live_display.display_id,
+                &live_display.display_type,
+            )
+        });
+        let phone_display = phone_profile.and_then(|pp| {
+            pp.displays.iter().find(|d| {
+                display_matches(
+                    d,
+                    live_display.service_id,
+                    live_display.display_id,
+                    &live_display.display_type,
+                )
+            })
+        });
+
+        for live_video in &live_display.video_configs {
+            let vehicle_video = vehicle_display.and_then(|d| {
+                d.video_configs
+                    .iter()
+                    .find(|v| v.enabled && v.codec_resolution == live_video.codec_resolution)
+            });
+            let phone_video = phone_display.and_then(|d| {
+                d.video_configs
+                    .iter()
+                    .find(|v| v.enabled && v.codec_resolution == live_video.codec_resolution)
+            });
+
+            let vehicle_margins = vehicle_video.and_then(|v| v.margins.as_ref());
+            let phone_margins = phone_video.and_then(|v| v.margins.as_ref());
+            if vehicle_margins.is_none() && phone_margins.is_none() {
+                continue;
+            }
+
+            let baseline = live_video.margins.clone().unwrap_or_default();
+            let pick = |get: fn(&SdrUiInsets) -> Option<u32>, base: Option<u32>| -> u32 {
+                phone_margins
+                    .and_then(get)
+                    .or_else(|| vehicle_margins.and_then(get))
+                    .or(base)
+                    .unwrap_or(0)
+            };
+
+            let label = format!("{}/{}", vehicle_profile.id, live_display.display_type);
+            let left = clamp_edge(pick(|i| i.left, baseline.left), &label, "left");
+            let top = clamp_edge(pick(|i| i.top, baseline.top), &label, "top");
+            let right = clamp_edge(pick(|i| i.right, baseline.right), &label, "right");
+            let bottom = clamp_edge(pick(|i| i.bottom, baseline.bottom), &label, "bottom");
+            let (left, top, right, bottom) = clamp_margins_to_resolution(
+                left,
+                top,
+                right,
+                bottom,
+                &live_video.codec_resolution,
+                &label,
+            );
+
+            let mut insets = VideoInsets::new();
+            insets.set_left(left);
+            insets.set_top(top);
+            insets.set_right(right);
+            insets.set_bottom(bottom);
+
+            let mut margin_config = VideoMarginConfig::new();
+            margin_config.insets = Some(insets).into();
+
+            let mut config = AdditionalVideoConfig::new();
+            config.margin_configs.push(margin_config);
+
+            updates.push((channel, config));
+        }
+    }
+
+    updates
+}
+
+fn clamp_margins_to_resolution(
+    left: u32,
+    top: u32,
+    right: u32,
+    bottom: u32,
+    codec_resolution: &str,
+    label: &str,
+) -> (u32, u32, u32, u32) {
+    let Some((width, height)) = resolution_size(codec_resolution) else {
+        return (left, top, right, bottom);
+    };
+
+    let mut right = right;
+    if left.saturating_add(right) >= width {
+        let allowed_right = width
+            .saturating_sub(1)
+            .saturating_sub(left.min(width.saturating_sub(1)));
+        warn!(
+            "{} {} left+right exceeds width {}; reducing right to {}",
+            NAME, label, width, allowed_right
+        );
+        right = allowed_right;
+    }
+
+    let mut bottom = bottom;
+    if top.saturating_add(bottom) >= height {
+        let allowed_bottom = height
+            .saturating_sub(1)
+            .saturating_sub(top.min(height.saturating_sub(1)));
+        warn!(
+            "{} {} top+bottom exceeds height {}; reducing bottom to {}",
+            NAME, label, height, allowed_bottom
+        );
+        bottom = allowed_bottom;
+    }
+
+    (left, top, right, bottom)
+}
+
 fn display_matches(
     profile: &SdrUiDisplayProfile,
     service_id: Option<i32>,
@@ -989,5 +1172,107 @@ fn remove_file_if_empty(path: &Path) {
         if metadata.len() == 0 {
             let _ = fs::remove_file(path);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_video(resolution: &str, margins: Option<SdrUiInsets>) -> SdrUiVideoConfigProfile {
+        SdrUiVideoConfigProfile {
+            codec_resolution: resolution.to_string(),
+            enabled: true,
+            margins,
+            ..Default::default()
+        }
+    }
+
+    fn sample_display(margins: Option<SdrUiInsets>) -> SdrUiDisplayProfile {
+        SdrUiDisplayProfile {
+            service_id: Some(3),
+            display_id: 0,
+            display_type: "DISPLAY_TYPE_MAIN".to_string(),
+            video_configs: vec![sample_video("VIDEO_800x480", margins)],
+        }
+    }
+
+    #[test]
+    fn live_margin_update_layers_phone_over_vehicle_and_clamps_to_resolution() {
+        let baseline_display = sample_display(Some(SdrUiInsets {
+            top: Some(0),
+            bottom: Some(0),
+            left: Some(0),
+            right: Some(0),
+        }));
+        let current = SdrUiCurrent {
+            vehicle_id: "veh_test".to_string(),
+            displays: vec![baseline_display],
+            ..Default::default()
+        };
+        *CURRENT_SDR_UI.lock().unwrap() = Some(current);
+
+        let mut vehicle_display = sample_display(Some(SdrUiInsets {
+            top: Some(10),
+            bottom: Some(10),
+            left: Some(10),
+            right: Some(790), // intentionally exceeds width; should get clamped
+        }));
+        vehicle_display.video_configs[0].enabled = true;
+
+        let phone_display = sample_display(Some(SdrUiInsets {
+            top: Some(20),
+            bottom: None,
+            left: None,
+            right: None,
+        }));
+
+        let vehicle_profile = SdrUiVehicleProfile {
+            id: "veh_test".to_string(),
+            enabled: true,
+            displays: vec![vehicle_display],
+            phones: vec![SdrUiPhoneProfile {
+                id: "phone_test".to_string(),
+                enabled: true,
+                displays: vec![phone_display],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let phone = PhoneIdentity {
+            id: "phone_test".to_string(),
+            ..Default::default()
+        };
+
+        let updates = resolve_live_margin_updates(&vehicle_profile, Some(&phone));
+        assert_eq!(updates.len(), 1);
+        let (channel, config) = &updates[0];
+        assert_eq!(*channel, 3);
+
+        let insets = config.margin_configs[0].insets.as_ref().unwrap();
+        assert_eq!(insets.top(), 20); // phone overrides vehicle
+        assert_eq!(insets.bottom(), 10); // falls back to vehicle (phone leaves it unset)
+        assert_eq!(insets.left(), 10); // vehicle value
+        assert_eq!(insets.right(), 789); // clamped: width 800, left 10 -> max right 789
+
+        *CURRENT_SDR_UI.lock().unwrap() = None;
+    }
+
+    #[test]
+    fn no_live_update_when_no_session_matches_vehicle() {
+        *CURRENT_SDR_UI.lock().unwrap() = None;
+        let vehicle_profile = SdrUiVehicleProfile {
+            id: "veh_other".to_string(),
+            enabled: true,
+            displays: vec![sample_display(Some(SdrUiInsets {
+                top: Some(5),
+                bottom: Some(5),
+                left: Some(5),
+                right: Some(5),
+            }))],
+            ..Default::default()
+        };
+        assert!(resolve_live_margin_updates(&vehicle_profile, None).is_empty());
     }
 }

--- a/src/sdr_ui_preview.rs
+++ b/src/sdr_ui_preview.rs
@@ -1,0 +1,149 @@
+use crate::map_album_art_h264::{
+    encode_rgb_png, feed_codec_config_to_decoder, yuv420_pixel_to_rgb,
+};
+use crate::media_tap::MediaSink;
+use log::info;
+use rust_h264::decoder::{Decoder, Frame};
+use rust_h264::nal::parse_annex_b;
+use std::time::{Duration, Instant};
+
+/// Result of [`render_last_idr_burst_png`]: the rendered PNG plus how long
+/// ago the burst's IDR was cached, so the caller can show an honest "this
+/// frame is N seconds old" indicator instead of presenting it as live.
+pub struct RenderedPreview {
+    pub png: Vec<u8>,
+    pub age: Duration,
+    /// (first unit's pts_us, unit count) of the burst that was actually
+    /// decoded -- lets the caller build an ETag that's guaranteed to match
+    /// what's in `png`, even if the live burst grew further while this
+    /// decode was running.
+    pub burst_version: (u64, usize),
+}
+
+/// Decodes the given sink's current IDR burst (the cached IDR plus the short
+/// contiguous run of access units captured right after it -- see
+/// `MediaSink::get_idr_burst`) into a full-frame PNG (no crop, unlike the
+/// square album-art thumbnail), scaled down to fit within `max_dimension` on
+/// its longest side.
+///
+/// We deliberately decode the *whole* burst, not just the IDR: P-frames only
+/// decode correctly as an unbroken chain from their reference frame, so this
+/// gives a temporally coherent picture from up to ~2s past the keyframe,
+/// without the gap-induced corruption that splicing in arbitrary later live
+/// frames would cause. It's still a still frame refreshed on demand, not a
+/// live feed, and its age (relative to the burst's IDR) is returned alongside
+/// so the UI can be honest about how current it actually is.
+///
+/// The actual decode + pixel conversion is pure synchronous CPU work with no
+/// `.await` points -- feeding a multi-second burst (hundreds of NAL units)
+/// through it can take long enough to stall the tokio scheduler if run
+/// directly on an async worker thread (observed as multi-second
+/// scheduler-probe tick gaps, i.e. the whole proxy stalling while a preview
+/// was requested). Runs on the blocking thread pool via spawn_blocking so it
+/// can't starve the runtime regardless of how long it takes.
+pub async fn render_last_idr_burst_png(
+    sink: &MediaSink,
+    channel: u8,
+    max_dimension: u32,
+) -> Result<RenderedPreview, String> {
+    let codec_cfg = sink
+        .get_codec_cfg()
+        .await
+        .ok_or_else(|| format!("ch {channel:#04x}: no codec config cached yet for this channel"))?;
+    let (cached_at, units) = sink
+        .get_idr_burst()
+        .await
+        .ok_or_else(|| format!("ch {channel:#04x}: no IDR frame cached yet for this channel"))?;
+    if units.is_empty() {
+        return Err(format!("ch {channel:#04x}: cached IDR burst was empty"));
+    }
+    let first_pts = units[0].0;
+    let unit_count = units.len();
+    let pts_span_us = units
+        .last()
+        .map(|(pts, _)| pts.saturating_sub(first_pts))
+        .unwrap_or(0);
+    info!(
+        "sdr_ui_preview: ch {:#04x}: decode starting, burst has {} unit(s), pts span {:?}, IDR age {:?}",
+        channel,
+        unit_count,
+        Duration::from_micros(pts_span_us),
+        cached_at.elapsed()
+    );
+
+    let decode_started_at = Instant::now();
+    let png =
+        tokio::task::spawn_blocking(move || decode_burst_to_png(&codec_cfg, &units, max_dimension))
+            .await
+            .map_err(|e| format!("ch {channel:#04x}: preview decode task panicked: {e}"))??;
+    info!(
+        "sdr_ui_preview: ch {:#04x}: decode finished, {} unit(s) in {:?}",
+        channel,
+        unit_count,
+        decode_started_at.elapsed()
+    );
+
+    Ok(RenderedPreview {
+        png,
+        age: cached_at.elapsed(),
+        burst_version: (first_pts, unit_count),
+    })
+}
+
+fn decode_burst_to_png(
+    codec_cfg: &[u8],
+    units: &[(u64, Vec<u8>)],
+    max_dimension: u32,
+) -> Result<Vec<u8>, String> {
+    let mut decoder = Decoder::new();
+    feed_codec_config_to_decoder(&mut decoder, codec_cfg)?;
+
+    let mut frame = None;
+    for (_, au) in units {
+        let nals = parse_annex_b(au);
+        for nal in &nals {
+            match decoder.decode_nal(nal) {
+                Ok(Some(f)) => frame = Some(f),
+                Ok(None) => {}
+                Err(e) => return Err(format!("decoder error: {}", e)),
+            }
+        }
+    }
+    // Whatever picture the last access unit started is still buffered as
+    // "pending" -- flush() finalizes it since there's no following picture
+    // in this burst to do so.
+    if let Some(flushed) = decoder.flush() {
+        frame = Some(flushed);
+    }
+
+    let frame = frame.ok_or_else(|| "cached IDR burst did not decode to a frame".to_string())?;
+    frame_to_full_png(&frame, max_dimension)
+}
+
+fn frame_to_full_png(frame: &Frame, max_dimension: u32) -> Result<Vec<u8>, String> {
+    let width = frame.width as usize;
+    let height = frame.height as usize;
+    if width == 0 || height == 0 {
+        return Err("decoded frame has empty dimensions".to_string());
+    }
+
+    let longest = width.max(height) as f64;
+    let scale = (max_dimension as f64 / longest).min(1.0);
+    let out_w = ((width as f64 * scale).round() as usize).max(1);
+    let out_h = ((height as f64 * scale).round() as usize).max(1);
+
+    let mut rgb = vec![0u8; out_w * out_h * 3];
+    for oy in 0..out_h {
+        let sy = (oy * height / out_h).min(height - 1);
+        for ox in 0..out_w {
+            let sx = (ox * width / out_w).min(width - 1);
+            let (r, g, b) = yuv420_pixel_to_rgb(frame, width, height, sx, sy);
+            let idx = (oy * out_w + ox) * 3;
+            rgb[idx] = r;
+            rgb[idx + 1] = g;
+            rgb[idx + 2] = b;
+        }
+    }
+
+    encode_rgb_png(out_w as u32, out_h as u32, &rgb)
+}

--- a/src/web.rs
+++ b/src/web.rs
@@ -30,11 +30,12 @@ use crate::mitm::Result;
 use crate::mitm::SharedServiceDiscoveryResponse;
 use crate::mitm::{send_odometer_data, OdometerData};
 use crate::mitm::{send_tire_pressure_data, TirePressureData};
-use crate::mitm::{SharedCompanionIp, SharedMediaTapEndpoints};
+use crate::mitm::{SharedCompanionIp, SharedMediaChannels, SharedMediaTapEndpoints};
 use crate::proxy::media_tap_reverse_bridge_once;
 #[cfg(feature = "wasm-scripting")]
 use crate::script_wasm::{LoadedScript, ScriptRegistry};
 use crate::sdr_ui;
+use crate::sdr_ui_preview;
 #[cfg(not(feature = "wasm-scripting"))]
 type ScriptRegistry = ();
 use axum::{
@@ -147,6 +148,7 @@ pub struct AppState {
     pub last_speed: Arc<RwLock<Option<i32>>>,
     pub last_service_discovery_response: SharedServiceDiscoveryResponse,
     pub media_tap_endpoints: SharedMediaTapEndpoints,
+    pub shared_media_channels: SharedMediaChannels,
     pub companion_ip: SharedCompanionIp,
     pub last_tire_pressure_data: Arc<RwLock<Option<TirePressureData>>>,
     pub ws_event_tx: broadcast::Sender<ServerEvent>,
@@ -198,6 +200,7 @@ pub fn app(state: Arc<AppState>) -> Router {
         .route("/set-time", post(set_time_handler))
         .route("/speed", get(speed_handler))
         .route("/sdr-ui/current", get(sdr_ui_current_handler))
+        .route("/sdr-ui/preview/:channel", get(sdr_ui_preview_handler))
         .route("/sdr-ui/profiles", get(sdr_ui_profiles_list_handler))
         .route(
             "/sdr-ui/profiles/:vehicle_id",
@@ -1548,6 +1551,79 @@ async fn speed_handler(State(state): State<Arc<AppState>>) -> impl IntoResponse 
     }
 }
 
+/// Renders a still-frame PNG preview of a video channel's current IDR burst
+/// (the cached IDR plus a short contiguous run of frames after it -- see
+/// MediaSink::get_idr_burst), for the Display Margins web panel. Requires
+/// media_dump_base_port to be configured (media tap), since that's what
+/// populates the per-channel MediaSink registry this reads from. Returns 404
+/// if no sink/IDR is cached yet for the requested channel. The response
+/// carries an `X-Frame-Age-Secs` header (seconds since the burst's IDR was
+/// cached) so the UI can show how current the frame actually is, rather than
+/// presenting a possibly-stale frame as if it were live.
+async fn sdr_ui_preview_handler(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Path(channel): axum::extract::Path<u8>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    let sink = state
+        .shared_media_channels
+        .lock()
+        .await
+        .get(&channel)
+        .cloned();
+    let Some(sink) = sink else {
+        return (
+            StatusCode::NOT_FOUND,
+            "no media sink for this channel yet (is media_dump_base_port configured?)",
+        )
+            .into_response();
+    };
+
+    // Cheap identity check (no decode) so a conditional request for a burst
+    // that hasn't changed since the browser last fetched it can be answered
+    // with 304 instead of paying the multi-second decode again.
+    if let Some((first_pts, unit_count)) = sink.get_idr_burst_version().await {
+        let etag = format!("\"{channel:x}-{first_pts:x}-{unit_count:x}\"");
+        let if_none_match = headers
+            .get(header::IF_NONE_MATCH)
+            .and_then(|v| v.to_str().ok());
+        if if_none_match == Some(etag.as_str()) {
+            return (
+                StatusCode::NOT_MODIFIED,
+                [(header::CACHE_CONTROL, "no-cache"), (header::ETAG, &etag)],
+            )
+                .into_response();
+        }
+    }
+
+    match sdr_ui_preview::render_last_idr_burst_png(&sink, channel, 960).await {
+        Ok(rendered) => {
+            let (first_pts, unit_count) = rendered.burst_version;
+            let etag = format!("\"{channel:x}-{first_pts:x}-{unit_count:x}\"");
+            let response = Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_TYPE, "image/png")
+                .header(header::CACHE_CONTROL, "no-cache")
+                .header(header::ETAG, etag)
+                .header("x-frame-age-secs", rendered.age.as_secs().to_string())
+                .body(Body::from(rendered.png));
+            match response {
+                Ok(response) => response.into_response(),
+                Err(e) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("failed to build response: {}", e),
+                )
+                    .into_response(),
+            }
+        }
+        Err(e) => (
+            StatusCode::NOT_FOUND,
+            format!("no preview frame available yet: {e}"),
+        )
+            .into_response(),
+    }
+}
+
 async fn sdr_ui_current_handler() -> impl IntoResponse {
     if let Some(current) = sdr_ui::current_sdr_ui() {
         Json(current).into_response()
@@ -1615,11 +1691,19 @@ async fn sdr_ui_profile_put_handler(
 ) -> impl IntoResponse {
     let path = state.config.read().await.sdr_ui_override_file.clone();
     match sdr_ui::upsert_vehicle_profile(path, &vehicle_id, profile).await {
-        Ok(saved) => Json(json!({
-            "status": "success",
-            "profile": saved,
-        }))
-        .into_response(),
+        Ok(saved) => {
+            let live_push_channels = if let Some(tx) = state.tx.lock().await.clone() {
+                sdr_ui::push_live_margin_updates(tx, &saved).await
+            } else {
+                0
+            };
+            Json(json!({
+                "status": "success",
+                "profile": saved,
+                "live_push_channels": live_push_channels,
+            }))
+            .into_response()
+        }
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({
@@ -2392,5 +2476,157 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mitm::protos::{
+        DisplayType, MediaSinkService, Service, ServiceDiscoveryResponse, VideoCodecResolutionType,
+        VideoConfiguration,
+    };
+
+    async fn test_state() -> Arc<AppState> {
+        let mut cfg = AppConfig::default();
+        cfg.sdr_ui_override_file = std::env::temp_dir().join(format!(
+            "aa-proxy-rs-test-sdr-ui-{}-{}.toml",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+
+        let (ws_event_tx, _rx) = broadcast::channel(16);
+
+        Arc::new(AppState {
+            config: Arc::new(RwLock::new(cfg)),
+            config_json: Arc::new(RwLock::new(ConfigJson::default())),
+            config_file: Arc::new(PathBuf::from("/tmp/aa-proxy-rs-test-config.toml")),
+            tx: Arc::new(Mutex::new(None)),
+            sensor_channel: Arc::new(Mutex::new(None)),
+            input_channel: Arc::new(Mutex::new(None)),
+            last_battery_data: Arc::new(RwLock::new(None)),
+            last_odometer_data: Arc::new(RwLock::new(None)),
+            last_speed: Arc::new(RwLock::new(None)),
+            last_service_discovery_response: Arc::new(RwLock::new(None)),
+            media_tap_endpoints: Arc::new(RwLock::new(Vec::new())),
+            shared_media_channels: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            companion_ip: Arc::new(RwLock::new(None)),
+            last_tire_pressure_data: Arc::new(RwLock::new(None)),
+            ws_event_tx,
+            script_registry: None,
+        })
+    }
+
+    fn sample_sdr_with_main_display() -> ServiceDiscoveryResponse {
+        let mut video_cfg = VideoConfiguration::new();
+        video_cfg.set_codec_resolution(VideoCodecResolutionType::VIDEO_800x480);
+
+        let mut sink = MediaSinkService::new();
+        sink.video_configs.push(video_cfg);
+        sink.set_display_id(0);
+        sink.set_display_type(DisplayType::DISPLAY_TYPE_MAIN);
+
+        let mut svc = Service::new();
+        svc.set_id(3);
+        svc.media_sink_service = Some(sink).into();
+
+        let mut msg = ServiceDiscoveryResponse::new();
+        msg.services.push(svc);
+        msg
+    }
+
+    /// Exercises the exact HTTP surface the new Display Margins web panel
+    /// drives: GET /sdr-ui/current (to discover displays/baseline margins)
+    /// and PUT /sdr-ui/profiles/:vehicle_id (the "Apply & push live" button),
+    /// confirming the JSON shapes the frontend JS assumes actually hold.
+    #[tokio::test]
+    async fn margins_panel_endpoints_round_trip() {
+        let state = test_state().await;
+
+        // Populate the live SDR-UI snapshot the same way a real connection
+        // would, via the real process_service_discovery_response path.
+        let mut sdr = sample_sdr_with_main_display();
+        let cfg_snapshot = state.config.read().await.clone();
+        sdr_ui::process_service_discovery_response(&mut sdr, &cfg_snapshot)
+            .await
+            .expect("process_service_discovery_response");
+
+        let app = app(state.clone());
+        let server =
+            hyper::Server::bind(&"127.0.0.1:0".parse().unwrap()).serve(app.into_make_service());
+        let addr = server.local_addr();
+        tokio::spawn(server);
+        let base = format!("http://{addr}");
+
+        let current_url = format!("{base}/sdr-ui/current");
+        let current: serde_json::Value = tokio::task::spawn_blocking(move || {
+            let body = ureq::get(&current_url)
+                .call()
+                .expect("GET /sdr-ui/current")
+                .into_string()
+                .expect("read body");
+            serde_json::from_str(&body).expect("parse current json")
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(current["displays"].as_array().unwrap().len(), 1);
+        let display = &current["displays"][0];
+        assert_eq!(display["display_type"], "DISPLAY_TYPE_MAIN");
+        assert_eq!(display["service_id"], 3);
+        let video = &display["video_configs"][0];
+        assert_eq!(video["codec_resolution"], "VIDEO_800x480");
+        assert!(video["margins"].is_object());
+
+        let vehicle_id = current["vehicle_id"].as_str().unwrap().to_string();
+
+        // Simulate the "Apply & push live" button: PUT a profile with new
+        // margins for that display/video config, exactly as the panel's JS
+        // constructs it.
+        let profile = json!({
+            "id": vehicle_id,
+            "name": "Test Vehicle",
+            "enabled": true,
+            "info": {},
+            "displays": [{
+                "service_id": 3,
+                "display_id": 0,
+                "display_type": "DISPLAY_TYPE_MAIN",
+                "video_configs": [{
+                    "codec_resolution": "VIDEO_800x480",
+                    "enabled": true,
+                    "margins": {"top": 12, "bottom": 8, "left": 4, "right": 4},
+                }],
+            }],
+            "phones": [],
+        });
+
+        let put_url = format!("{base}/sdr-ui/profiles/{vehicle_id}");
+        let put_resp: serde_json::Value = tokio::task::spawn_blocking(move || {
+            let body = ureq::put(&put_url)
+                .set("content-type", "application/json")
+                .send_string(&profile.to_string())
+                .expect("PUT /sdr-ui/profiles")
+                .into_string()
+                .expect("read body");
+            serde_json::from_str(&body).expect("parse put response")
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(put_resp["status"], "success");
+        // No phone tx is wired up in this test, so nothing was pushed live --
+        // this also confirms the "no active session" branch the web UI
+        // handles (it shows "Saved -- will apply on next reconnect").
+        assert_eq!(put_resp["live_push_channels"], 0);
+
+        let saved_margins = &put_resp["profile"]["displays"][0]["video_configs"][0]["margins"];
+        assert_eq!(saved_margins["top"], 12);
+        assert_eq!(saved_margins["right"], 4);
+
+        let _ = std::fs::remove_file(&cfg_snapshot.sdr_ui_override_file);
     }
 }

--- a/static/index.html
+++ b/static/index.html
@@ -348,10 +348,10 @@
         <p class="margins-hint" id="margins-hint" hidden>
           Saves margins, content insets, and stable content insets for this
           display. Android Auto only reads these from the initial connection
-          handshake on most phones we've tested -- changes reliably take
-          effect on the <em>next</em> phone connection, not immediately.
-          (For margins only, a best-effort live update is also attempted,
-          but isn't guaranteed to have a visible effect.)
+          handshake -- changes take effect on the <em>next</em> phone
+          connection, not immediately. (For margins only, a live update is
+          also attempted in the background; on every phone tested so far it
+          had no visible effect, so treat it as a no-op, not a shortcut.)
         </p>
       </div>
     </aside>
@@ -1258,12 +1258,11 @@
       // (see /sdr-ui/current, /sdr-ui/profiles). Saves margins, content
       // insets, and stable content insets for a display/resolution.
       //
-      // Note: on real phones we've tested, Android Auto only reads these
-      // from the initial connection handshake -- a best-effort live push
-      // (UpdateUiConfigRequest / wire 0x800A) is attempted for margins
-      // only, since that's the only one of the three with a runtime wire
-      // equivalent, but it is NOT guaranteed to have a visible effect.
-      // Changes reliably apply on the next phone connection.
+      // Note: Android Auto only reads these from the initial connection
+      // handshake -- a live push (UpdateUiConfigRequest / wire 0x800A) is
+      // attempted for margins only, since that's the only one of the three
+      // with a runtime wire equivalent, but on every phone tested so far it
+      // had no visible effect. Changes apply on the next phone connection.
       // ============================================================
 
       const MARGINS_INSET_TYPES = ["margins", "content_insets", "stable_content_insets"];
@@ -1711,7 +1710,7 @@
           const pushed = body.live_push_channels || 0;
           showSnackbar(
             pushed > 0
-              ? `Saved -- applies on next phone connection. (Margin update also sent live to ${pushed} channel(s); not guaranteed visible without a reconnect.)`
+              ? `Saved -- applies on next phone connection. (Margin update also sent live to ${pushed} channel(s), but this has had no visible effect on any phone tested so far.)`
               : "Saved -- applies on next phone connection.",
             "success",
           );

--- a/static/index.html
+++ b/static/index.html
@@ -25,6 +25,14 @@
       </button>
       <button
         type="button"
+        class="rail-btn drawer-toggle"
+        id="margins-drawer-toggle"
+        data-label="Display Margins"
+      >
+        📐
+      </button>
+      <button
+        type="button"
         class="rail-btn download-btn"
         data-label="Download Log Package (.tar.gz)"
       >
@@ -243,6 +251,108 @@
             </button>
           </div>
         </div>
+      </div>
+    </aside>
+
+    <aside class="controller-drawer" id="margins-drawer" aria-hidden="true">
+      <div class="controller-drawer-header">
+        <div class="controller-drawer-title">
+          <span>📐</span><span>Display Margins</span>
+        </div>
+        <button
+          type="button"
+          class="controller-drawer-close"
+          id="margins-drawer-close"
+          aria-label="Close display margins panel"
+        >
+          ×
+        </button>
+      </div>
+      <div class="controller-drawer-body">
+        <p class="margins-status" id="margins-status">Loading current display…</p>
+
+        <div class="margins-field" id="margins-display-field" hidden>
+          <label for="margins-display-select">Display</label>
+          <select id="margins-display-select"></select>
+        </div>
+
+        <div class="margins-type-tabs" id="margins-type-tabs" hidden>
+          <button type="button" class="margins-type-tab" data-inset-type="margins">
+            Margins
+          </button>
+          <button type="button" class="margins-type-tab" data-inset-type="content_insets">
+            Content insets
+          </button>
+          <button type="button" class="margins-type-tab" data-inset-type="stable_content_insets">
+            Stable content insets
+          </button>
+        </div>
+        <p class="margins-type-hint" id="margins-type-hint" hidden></p>
+
+        <div class="margins-preview-wrap" id="margins-preview-wrap" hidden>
+          <div class="margins-preview" id="margins-preview">
+            <img
+              class="margins-preview-frame"
+              id="margins-preview-frame"
+              alt="Last captured frame on this channel"
+            />
+            <div class="margins-preview-band margins-preview-top" id="margins-preview-top"></div>
+            <div class="margins-preview-band margins-preview-bottom" id="margins-preview-bottom"></div>
+            <div class="margins-preview-band margins-preview-left" id="margins-preview-left"></div>
+            <div class="margins-preview-band margins-preview-right" id="margins-preview-right"></div>
+            <div class="margins-preview-safe" id="margins-preview-safe">
+              <span id="margins-preview-placeholder-label">Projected UI</span>
+            </div>
+            <span
+              class="margins-preview-age"
+              id="margins-preview-age"
+              hidden
+            ></span>
+          </div>
+          <p class="margins-preview-caption" id="margins-preview-caption"></p>
+          <button type="button" id="margins-preview-refresh-btn" class="margins-preview-refresh">
+            🔄 Refresh frame
+          </button>
+        </div>
+
+        <div class="margins-sliders" id="margins-sliders" hidden>
+          <div class="margins-slider-row">
+            <label for="margin-top">Top</label>
+            <input type="range" id="margin-top" min="0" max="0" value="0" />
+            <input type="number" id="margin-top-num" min="0" max="0" value="0" />
+          </div>
+          <div class="margins-slider-row">
+            <label for="margin-bottom">Bottom</label>
+            <input type="range" id="margin-bottom" min="0" max="0" value="0" />
+            <input type="number" id="margin-bottom-num" min="0" max="0" value="0" />
+          </div>
+          <div class="margins-slider-row">
+            <label for="margin-left">Left</label>
+            <input type="range" id="margin-left" min="0" max="0" value="0" />
+            <input type="number" id="margin-left-num" min="0" max="0" value="0" />
+          </div>
+          <div class="margins-slider-row">
+            <label for="margin-right">Right</label>
+            <input type="range" id="margin-right" min="0" max="0" value="0" />
+            <input type="number" id="margin-right-num" min="0" max="0" value="0" />
+          </div>
+        </div>
+
+        <div class="margins-actions" id="margins-actions" hidden>
+          <button type="button" id="margins-reset-btn">↺ Reset</button>
+          <button type="button" id="margins-apply-btn" class="margins-apply">
+            ✅ Save
+          </button>
+        </div>
+
+        <p class="margins-hint" id="margins-hint" hidden>
+          Saves margins, content insets, and stable content insets for this
+          display. Android Auto only reads these from the initial connection
+          handshake on most phones we've tested -- changes reliably take
+          effect on the <em>next</em> phone connection, not immediately.
+          (For margins only, a best-effort live update is also attempted,
+          but isn't guaranteed to have a visible effect.)
+        </p>
       </div>
     </aside>
 
@@ -473,29 +583,45 @@
 
         setupMobileLongPressLabels();
 
-        // Controller-panel drawer: toggle via rail button, close via X
-        // button, scrim click, or Esc.
-        const drawer = document.getElementById("controller-drawer");
-        const drawerToggle = document.getElementById(
-          "controller-drawer-toggle",
-        );
-        const drawerClose = document.getElementById("controller-drawer-close");
+        // Side drawers (Controller Panel, Display Margins): toggled via rail
+        // buttons, closed via X / scrim click / Esc. Share one scrim and are
+        // mutually exclusive -- opening one closes the other.
         const drawerScrim = document.getElementById("drawer-scrim");
-        const setDrawerOpen = (open) => {
-          drawer.classList.toggle("open", open);
-          drawerScrim.classList.toggle("open", open);
-          drawerToggle.classList.toggle("open", open);
-          drawer.setAttribute("aria-hidden", open ? "false" : "true");
+        const drawers = [
+          {
+            aside: document.getElementById("controller-drawer"),
+            toggle: document.getElementById("controller-drawer-toggle"),
+            close: document.getElementById("controller-drawer-close"),
+          },
+          {
+            aside: document.getElementById("margins-drawer"),
+            toggle: document.getElementById("margins-drawer-toggle"),
+            close: document.getElementById("margins-drawer-close"),
+            onOpen: () => initMarginsPanel(),
+          },
+        ];
+        const setActiveDrawer = (target) => {
+          let anyOpen = false;
+          drawers.forEach((d) => {
+            const open = d.aside === target;
+            d.aside.classList.toggle("open", open);
+            d.toggle.classList.toggle("open", open);
+            d.aside.setAttribute("aria-hidden", open ? "false" : "true");
+            anyOpen = anyOpen || open;
+          });
+          drawerScrim.classList.toggle("open", anyOpen);
+          if (target && target._onOpen) target._onOpen();
         };
-        drawerToggle.addEventListener("click", () => {
-          setDrawerOpen(!drawer.classList.contains("open"));
+        drawers.forEach((d) => {
+          d.aside._onOpen = d.onOpen;
+          d.toggle.addEventListener("click", () => {
+            setActiveDrawer(d.aside.classList.contains("open") ? null : d.aside);
+          });
+          d.close.addEventListener("click", () => setActiveDrawer(null));
         });
-        drawerClose.addEventListener("click", () => setDrawerOpen(false));
-        drawerScrim.addEventListener("click", () => setDrawerOpen(false));
+        drawerScrim.addEventListener("click", () => setActiveDrawer(null));
         document.addEventListener("keydown", (e) => {
-          if (e.key === "Escape" && drawer.classList.contains("open")) {
-            setDrawerOpen(false);
-          }
+          if (e.key === "Escape") setActiveDrawer(null);
         });
 
         loadConfig();
@@ -1124,6 +1250,477 @@
             snackbar.hidden = true;
           }, 220);
         }, 2600);
+      }
+
+      // ============================================================
+      // DISPLAY MARGINS PANEL
+      // Live-preview editor for the SDR UI margin/inset overrides
+      // (see /sdr-ui/current, /sdr-ui/profiles). Saves margins, content
+      // insets, and stable content insets for a display/resolution.
+      //
+      // Note: on real phones we've tested, Android Auto only reads these
+      // from the initial connection handshake -- a best-effort live push
+      // (UpdateUiConfigRequest / wire 0x800A) is attempted for margins
+      // only, since that's the only one of the three with a runtime wire
+      // equivalent, but it is NOT guaranteed to have a visible effect.
+      // Changes reliably apply on the next phone connection.
+      // ============================================================
+
+      const MARGINS_INSET_TYPES = ["margins", "content_insets", "stable_content_insets"];
+
+      const marginsState = {
+        loaded: false,
+        vehicleId: null,
+        vehicleName: null,
+        displays: [],
+        profile: null,
+        selectedDisplayIdx: 0,
+        selectedVideoIdx: 0,
+        currentSize: null,
+        activeType: "margins",
+        values: {
+          margins: { top: 0, bottom: 0, left: 0, right: 0 },
+          content_insets: { top: 0, bottom: 0, left: 0, right: 0 },
+          stable_content_insets: { top: 0, bottom: 0, left: 0, right: 0 },
+        },
+      };
+      let marginsControlsWired = false;
+
+      async function initMarginsPanel() {
+        if (marginsState.loaded) return;
+        await reloadMarginsPanel();
+      }
+
+      async function reloadMarginsPanel() {
+        const statusEl = document.getElementById("margins-status");
+        const fieldEl = document.getElementById("margins-display-field");
+        const tabsEl = document.getElementById("margins-type-tabs");
+        const typeHintEl = document.getElementById("margins-type-hint");
+        const previewWrap = document.getElementById("margins-preview-wrap");
+        const slidersEl = document.getElementById("margins-sliders");
+        const actionsEl = document.getElementById("margins-actions");
+        const hintEl = document.getElementById("margins-hint");
+
+        statusEl.textContent = "Loading current display…";
+        [fieldEl, tabsEl, typeHintEl, previewWrap, slidersEl, actionsEl, hintEl].forEach(
+          (el) => (el.hidden = true),
+        );
+
+        let current;
+        try {
+          const res = await fetch("/sdr-ui/current");
+          if (!res.ok) {
+            statusEl.textContent =
+              "No Android Auto session detected yet. Connect a phone, then reopen this panel.";
+            return;
+          }
+          current = await res.json();
+        } catch (e) {
+          statusEl.textContent =
+            "Failed to load current display info: " + e.message;
+          return;
+        }
+
+        if (!current.displays || current.displays.length === 0) {
+          statusEl.textContent =
+            "Connected, but no video displays were reported yet.";
+          return;
+        }
+
+        marginsState.vehicleId = current.vehicle_id;
+        marginsState.vehicleName = current.vehicle_name;
+        marginsState.displays = current.displays;
+        marginsState.profile = await fetchOrCreateMarginsProfile(current);
+        marginsState.loaded = true;
+
+        const select = document.getElementById("margins-display-select");
+        select.innerHTML = "";
+        current.displays.forEach((display, dIdx) => {
+          display.video_configs.forEach((video, vIdx) => {
+            const opt = document.createElement("option");
+            opt.value = `${dIdx}:${vIdx}`;
+            opt.textContent = `${formatDisplayType(display.display_type)} — ${formatResolution(video.codec_resolution)}`;
+            select.appendChild(opt);
+          });
+        });
+        select.onchange = () => {
+          const [dIdx, vIdx] = select.value.split(":").map(Number);
+          marginsState.selectedDisplayIdx = dIdx;
+          marginsState.selectedVideoIdx = vIdx;
+          populateMarginsSlidersFromState();
+          loadPreviewFrame();
+        };
+        marginsState.selectedDisplayIdx = 0;
+        marginsState.selectedVideoIdx = 0;
+        select.value = "0:0";
+
+        statusEl.textContent = `Connected: ${current.vehicle_name || current.vehicle_id}`;
+        fieldEl.hidden = false;
+        tabsEl.hidden = false;
+        typeHintEl.hidden = false;
+        previewWrap.hidden = false;
+        slidersEl.hidden = false;
+        actionsEl.hidden = false;
+        hintEl.hidden = false;
+
+        marginsState.activeType = "margins";
+        setActiveInsetTypeTab("margins");
+        populateMarginsSlidersFromState();
+        wireMarginsControlsOnce();
+        loadPreviewFrame();
+      }
+
+      // Fetches a still-frame PNG of the selected display's last cached IDR
+      // (see GET /sdr-ui/preview/:channel) and shows it behind the margin
+      // bands. Falls back to the diagonal-stripe placeholder if no frame is
+      // available yet (e.g. media_dump_base_port isn't configured, or no
+      // IDR has been seen on this channel yet).
+      // Uses fetch() rather than a plain <img src=...> so we can read the
+      // X-Frame-Age-Secs response header -- the frame is decoded from a
+      // short burst starting at the channel's last IDR, which can be stale
+      // if the phone hasn't emitted a fresh keyframe recently, so the UI
+      // shows that age rather than presenting it as a live view.
+      //
+      // No cache-busting query param here, deliberately: the server sends
+      // an ETag identifying the current burst's content (Cache-Control:
+      // no-cache), so repeat fetches of the *same* URL let the browser send
+      // a conditional request and get a fast 304 instead of paying the
+      // multi-second decode again when the burst hasn't changed. A cache
+      // buster would defeat that by making every request a "new" URL.
+      async function loadPreviewFrame() {
+        const img = document.getElementById("margins-preview-frame");
+        const ageEl = document.getElementById("margins-preview-age");
+        const liveDisplay = marginsState.displays[marginsState.selectedDisplayIdx];
+        if (!liveDisplay || liveDisplay.service_id == null) {
+          img.classList.remove("loaded");
+          ageEl.hidden = true;
+          return;
+        }
+
+        try {
+          const res = await fetch(`/sdr-ui/preview/${liveDisplay.service_id}`);
+          if (!res.ok) {
+            img.classList.remove("loaded");
+            ageEl.hidden = true;
+            return;
+          }
+          const ageSecs = Number(res.headers.get("x-frame-age-secs") || "0");
+          const blob = await res.blob();
+          const url = URL.createObjectURL(blob);
+          const previous = img.dataset.objectUrl;
+          img.onload = () => {
+            img.classList.add("loaded");
+            if (previous) URL.revokeObjectURL(previous);
+          };
+          img.dataset.objectUrl = url;
+          img.src = url;
+
+          ageEl.hidden = false;
+          ageEl.textContent = ageSecs < 1 ? "just now" : `${ageSecs}s old`;
+          ageEl.classList.toggle("stale", ageSecs >= 10);
+        } catch (e) {
+          img.classList.remove("loaded");
+          ageEl.hidden = true;
+        }
+      }
+
+      const MARGINS_TYPE_LABELS = {
+        margins: "Margins",
+        content_insets: "Content insets",
+        stable_content_insets: "Stable content insets",
+      };
+      const MARGINS_TYPE_HINTS = {
+        margins:
+          "Outer padding around the projected UI -- also drives video letterboxing.",
+        content_insets:
+          "Safe area for interactive content (buttons, touch targets).",
+        stable_content_insets:
+          "Safe area that stays constant even when transient UI (e.g. the nav bar) is hidden.",
+      };
+
+      function setActiveInsetTypeTab(type) {
+        document.querySelectorAll(".margins-type-tab").forEach((btn) => {
+          btn.classList.toggle("active", btn.dataset.insetType === type);
+        });
+        document.getElementById("margins-type-hint").textContent =
+          MARGINS_TYPE_HINTS[type] || "";
+      }
+
+      async function fetchOrCreateMarginsProfile(current) {
+        try {
+          const res = await fetch(
+            `/sdr-ui/profiles/${encodeURIComponent(current.vehicle_id)}`,
+          );
+          if (res.ok) return await res.json();
+        } catch (_) {}
+        return {
+          id: current.vehicle_id,
+          name: current.vehicle_name || current.vehicle_id,
+          enabled: true,
+          info: current.vehicle_info || {},
+          displays: [],
+          phones: [],
+        };
+      }
+
+      function formatDisplayType(t) {
+        return (t || "").replace("DISPLAY_TYPE_", "");
+      }
+
+      function formatResolution(codecResolution) {
+        return (codecResolution || "").replace("VIDEO_", "");
+      }
+
+      function parseResolutionSize(codecResolution) {
+        const m = /VIDEO_(\d+)x(\d+)/i.exec(codecResolution || "");
+        if (!m) return null;
+        return { width: parseInt(m[1], 10), height: parseInt(m[2], 10) };
+      }
+
+      // Finds the saved vehicle-profile display/video entry matching a live
+      // snapshot entry, if one exists. Per-phone overrides are layered on
+      // top server-side and are not edited from this panel.
+      function findProfileVideo(profile, liveDisplay, liveVideo) {
+        const display = (profile.displays || []).find(
+          (d) =>
+            d.display_id === liveDisplay.display_id &&
+            d.display_type === liveDisplay.display_type,
+        );
+        if (!display) return null;
+        return (
+          (display.video_configs || []).find(
+            (v) => v.codec_resolution === liveVideo.codec_resolution,
+          ) || null
+        );
+      }
+
+      function resolveInsetValue(saved, baseline, edge) {
+        if (saved && saved[edge] != null) return saved[edge];
+        return (baseline && baseline[edge]) || 0;
+      }
+
+      // Loads margins, content_insets, and stable_content_insets for the
+      // currently selected display/resolution into marginsState.values
+      // (saved profile value if set, else the live baseline from
+      // /sdr-ui/current), then shows whichever type tab is active.
+      function populateMarginsSlidersFromState() {
+        const liveDisplay = marginsState.displays[marginsState.selectedDisplayIdx];
+        const liveVideo = liveDisplay.video_configs[marginsState.selectedVideoIdx];
+        const size =
+          parseResolutionSize(liveVideo.codec_resolution) || {
+            width: 1920,
+            height: 1080,
+          };
+
+        const profileVideo = findProfileVideo(
+          marginsState.profile,
+          liveDisplay,
+          liveVideo,
+        );
+
+        MARGINS_INSET_TYPES.forEach((type) => {
+          const saved = profileVideo && profileVideo[type];
+          const baseline = liveVideo[type] || {};
+          marginsState.values[type] = {
+            top: resolveInsetValue(saved, baseline, "top"),
+            bottom: resolveInsetValue(saved, baseline, "bottom"),
+            left: resolveInsetValue(saved, baseline, "left"),
+            right: resolveInsetValue(saved, baseline, "right"),
+          };
+        });
+
+        marginsState.currentSize = size;
+        loadActiveTypeIntoSliders();
+      }
+
+      function sliderMax(edge, size) {
+        return edge === "left" || edge === "right"
+          ? Math.max(0, Math.floor(size.width / 2) - 1)
+          : Math.max(0, Math.floor(size.height / 2) - 1);
+      }
+
+      // Pushes marginsState.values[activeType] into the DOM sliders.
+      function loadActiveTypeIntoSliders() {
+        const size = marginsState.currentSize || { width: 1920, height: 1080 };
+        const values = marginsState.values[marginsState.activeType];
+        ["top", "bottom", "left", "right"].forEach((edge) => {
+          setMarginSlider(edge, values[edge], sliderMax(edge, size));
+        });
+        renderMarginsPreview();
+      }
+
+      function setMarginSlider(edge, value, max) {
+        const range = document.getElementById(`margin-${edge}`);
+        const num = document.getElementById(`margin-${edge}-num`);
+        range.max = max;
+        num.max = max;
+        range.value = value;
+        num.value = value;
+      }
+
+      // Reads the DOM sliders (the active type's live edits) back into
+      // marginsState.values, and returns that type's values.
+      function syncActiveTypeFromSliders() {
+        const values = {
+          top: Number(document.getElementById("margin-top").value) || 0,
+          bottom: Number(document.getElementById("margin-bottom").value) || 0,
+          left: Number(document.getElementById("margin-left").value) || 0,
+          right: Number(document.getElementById("margin-right").value) || 0,
+        };
+        marginsState.values[marginsState.activeType] = values;
+        return values;
+      }
+
+      function renderMarginsPreview() {
+        const size = marginsState.currentSize || { width: 1920, height: 1080 };
+        const values = marginsState.values[marginsState.activeType];
+
+        const topPct = Math.min(100, (values.top / size.height) * 100);
+        const bottomPct = Math.min(100, (values.bottom / size.height) * 100);
+        const leftPct = Math.min(100, (values.left / size.width) * 100);
+        const rightPct = Math.min(100, (values.right / size.width) * 100);
+
+        document.getElementById("margins-preview-top").style.height =
+          `${topPct}%`;
+        document.getElementById("margins-preview-bottom").style.height =
+          `${bottomPct}%`;
+        document.getElementById("margins-preview-left").style.width =
+          `${leftPct}%`;
+        document.getElementById("margins-preview-right").style.width =
+          `${rightPct}%`;
+
+        document.getElementById("margins-preview").style.aspectRatio =
+          `${size.width} / ${size.height}`;
+
+        const typeLabel = MARGINS_TYPE_LABELS[marginsState.activeType] || "";
+        document.getElementById("margins-preview-caption").textContent =
+          `${typeLabel} — ${size.width}×${size.height} — top ${values.top}px, bottom ${values.bottom}px, left ${values.left}px, right ${values.right}px`;
+      }
+
+      function wireMarginsControlsOnce() {
+        if (marginsControlsWired) return;
+        marginsControlsWired = true;
+
+        ["top", "bottom", "left", "right"].forEach((edge) => {
+          const range = document.getElementById(`margin-${edge}`);
+          const num = document.getElementById(`margin-${edge}-num`);
+          range.addEventListener("input", () => {
+            num.value = range.value;
+            syncActiveTypeFromSliders();
+            renderMarginsPreview();
+          });
+          num.addEventListener("input", () => {
+            const max = Number(range.max) || 0;
+            let v = Number(num.value) || 0;
+            if (v > max) v = max;
+            if (v < 0) v = 0;
+            range.value = v;
+            syncActiveTypeFromSliders();
+            renderMarginsPreview();
+          });
+        });
+
+        document.querySelectorAll(".margins-type-tab").forEach((btn) => {
+          btn.addEventListener("click", () => {
+            syncActiveTypeFromSliders();
+            marginsState.activeType = btn.dataset.insetType;
+            setActiveInsetTypeTab(marginsState.activeType);
+            loadActiveTypeIntoSliders();
+          });
+        });
+
+        document
+          .getElementById("margins-reset-btn")
+          .addEventListener("click", () => populateMarginsSlidersFromState());
+
+        document
+          .getElementById("margins-preview-refresh-btn")
+          .addEventListener("click", () => loadPreviewFrame());
+
+        document
+          .getElementById("margins-apply-btn")
+          .addEventListener("click", applyMarginsLive);
+      }
+
+      async function applyMarginsLive() {
+        const applyBtn = document.getElementById("margins-apply-btn");
+        const liveDisplay =
+          marginsState.displays[marginsState.selectedDisplayIdx];
+        const liveVideo = liveDisplay.video_configs[marginsState.selectedVideoIdx];
+        syncActiveTypeFromSliders();
+        const values = marginsState.values;
+
+        applyBtn.disabled = true;
+        applyBtn.textContent = "⏳ Saving…";
+        try {
+          // Refetch right before saving to minimize clobbering edits made
+          // concurrently elsewhere (e.g. another browser tab).
+          const profile = await fetchOrCreateMarginsProfile({
+            vehicle_id: marginsState.vehicleId,
+            vehicle_name: marginsState.vehicleName,
+            vehicle_info: marginsState.profile.info,
+          });
+          profile.id = marginsState.vehicleId;
+          profile.enabled = true;
+          profile.displays = profile.displays || [];
+
+          let display = profile.displays.find(
+            (d) =>
+              d.display_id === liveDisplay.display_id &&
+              d.display_type === liveDisplay.display_type,
+          );
+          if (!display) {
+            display = {
+              service_id: liveDisplay.service_id,
+              display_id: liveDisplay.display_id,
+              display_type: liveDisplay.display_type,
+              video_configs: [],
+            };
+            profile.displays.push(display);
+          } else {
+            display.service_id = liveDisplay.service_id;
+          }
+          display.video_configs = display.video_configs || [];
+
+          let video = display.video_configs.find(
+            (v) => v.codec_resolution === liveVideo.codec_resolution,
+          );
+          if (!video) {
+            video = { codec_resolution: liveVideo.codec_resolution, enabled: true };
+            display.video_configs.push(video);
+          }
+          video.enabled = true;
+          video.margins = values.margins;
+          video.content_insets = values.content_insets;
+          video.stable_content_insets = values.stable_content_insets;
+
+          const res = await fetch(
+            `/sdr-ui/profiles/${encodeURIComponent(marginsState.vehicleId)}`,
+            {
+              method: "PUT",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(profile),
+            },
+          );
+          const body = await res.json();
+          if (!res.ok) {
+            throw new Error(body.message || `Status ${res.status}`);
+          }
+
+          marginsState.profile = body.profile;
+          const pushed = body.live_push_channels || 0;
+          showSnackbar(
+            pushed > 0
+              ? `Saved -- applies on next phone connection. (Margin update also sent live to ${pushed} channel(s); not guaranteed visible without a reconnect.)`
+              : "Saved -- applies on next phone connection.",
+            "success",
+          );
+        } catch (e) {
+          showSnackbar("Failed to save: " + e.message, "error");
+        } finally {
+          applyBtn.disabled = false;
+          applyBtn.textContent = "✅ Save";
+        }
       }
 
       async function saveConfig() {

--- a/static/styles.css
+++ b/static/styles.css
@@ -1444,3 +1444,244 @@ body.show-advanced .rail-advanced .rail-advanced-label {
     border-color: rgba(239, 68, 68, 0.65);
     box-shadow: 0 18px 45px rgba(0, 0, 0, 0.45), 0 0 28px rgba(239, 68, 68, 0.16);
 }
+
+/* ============================================================
+   DISPLAY MARGINS DRAWER
+   Live-preview margin/inset editor: a scaled box representing the
+   projected display with four overlay bands sized proportionally
+   to the current slider values, plus per-edge range + number inputs.
+   ============================================================ */
+
+#margins-status {
+    margin: 0 0 1rem;
+    font-size: 0.85rem;
+    font-weight: 400;
+    letter-spacing: normal;
+    text-transform: none;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.margins-field {
+    margin-bottom: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.margins-field label {
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--accent);
+}
+
+.margins-type-tabs {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.4rem;
+    margin-bottom: 0.75rem;
+}
+
+.margins-type-tab {
+    font-size: 0.7rem;
+    padding: 0.5rem 0.4rem;
+    text-align: center;
+    line-height: 1.2;
+}
+
+.margins-type-tab.active {
+    border-color: var(--accent) !important;
+    background-color: rgba(20, 184, 166, 0.16) !important;
+    color: #fff;
+}
+
+#margins-type-hint {
+    margin: 0 0 1rem;
+    font-size: 0.75rem;
+    font-weight: 400;
+    letter-spacing: normal;
+    text-transform: none;
+    color: rgba(255, 255, 255, 0.5);
+}
+
+.margins-preview-wrap {
+    margin-bottom: 1.5rem;
+}
+
+.margins-preview {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    background: repeating-linear-gradient(
+        45deg,
+        rgba(255, 255, 255, 0.03),
+        rgba(255, 255, 255, 0.03) 6px,
+        transparent 6px,
+        transparent 12px
+    );
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+.margins-preview-frame {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    background: #000;
+    /* Hidden until a frame actually loads; falls back to the diagonal-stripe
+       placeholder background + "Projected UI" label otherwise. */
+    display: none;
+}
+
+.margins-preview-frame.loaded {
+    display: block;
+}
+
+/* Hide the placeholder label once a real frame is showing -- the bands and
+   safe-area outline stay visible either way. */
+.margins-preview-frame.loaded ~ .margins-preview-safe #margins-preview-placeholder-label {
+    display: none;
+}
+
+.margins-preview-band {
+    position: absolute;
+    background: rgba(239, 68, 68, 0.32);
+    transition: width 80ms linear, height 80ms linear;
+}
+
+.margins-preview-top {
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 0%;
+    border-bottom: 1px dashed rgba(239, 68, 68, 0.6);
+}
+
+.margins-preview-bottom {
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 0%;
+    border-top: 1px dashed rgba(239, 68, 68, 0.6);
+}
+
+.margins-preview-left {
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 0%;
+    border-right: 1px dashed rgba(239, 68, 68, 0.6);
+}
+
+.margins-preview-right {
+    top: 0;
+    bottom: 0;
+    right: 0;
+    width: 0%;
+    border-left: 1px dashed rgba(239, 68, 68, 0.6);
+}
+
+.margins-preview-safe {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.margins-preview-safe span {
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.45);
+}
+
+.margins-preview-age {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    padding: 0.2rem 0.5rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: normal;
+    text-transform: none;
+    border-radius: 6px;
+    background: rgba(0, 0, 0, 0.55);
+    color: #fff;
+}
+
+.margins-preview-age.stale {
+    background: rgba(239, 68, 68, 0.75);
+}
+
+#margins-preview-caption {
+    margin: 0.6rem 0 0;
+    font-size: 0.75rem;
+    font-weight: 400;
+    letter-spacing: normal;
+    text-transform: none;
+    color: rgba(255, 255, 255, 0.55);
+    text-align: center;
+}
+
+.margins-preview-refresh {
+    display: block;
+    margin: 0.6rem auto 0;
+    font-size: 0.75rem;
+    padding: 0.4rem 0.75rem;
+}
+
+.margins-sliders {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-bottom: 1.25rem;
+}
+
+.margins-slider-row {
+    display: grid;
+    grid-template-columns: 4.2rem 1fr 4.2rem;
+    align-items: center;
+    gap: 0.6rem;
+}
+
+.margins-slider-row label {
+    font-size: 0.8rem;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.margins-slider-row input[type="range"] {
+    width: 100%;
+    accent-color: var(--accent);
+}
+
+.margins-slider-row input[type="number"] {
+    width: 100%;
+    margin: 0;
+}
+
+.margins-actions {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.6rem;
+    margin-bottom: 1rem;
+}
+
+.margins-apply {
+    border-color: var(--accent) !important;
+    background-color: rgba(20, 184, 166, 0.12) !important;
+}
+
+#margins-hint {
+    margin: 0;
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.45);
+    text-transform: none;
+    letter-spacing: normal;
+    font-weight: 400;
+}


### PR DESCRIPTION
Adds a webui to configure margins/insets. Has a preview from the stream that updates whenever keyframes (IDR/GOP) are received. The preview plays back 4 seconds of main screen so it won't just be a black screen or the android auto logo when it's starting.

In the first picture, note how the Google logo stays inside the inset. Margins let you set black area that isn't rendered.

<img width="871" height="1247" alt="image" src="https://github.com/user-attachments/assets/53da69ac-910f-4996-bd5b-e4720447cc87" />
<img width="466" height="622" alt="image" src="https://github.com/user-attachments/assets/493d968a-7897-45de-a625-dbe247d47f9c" />

Parts of the "stream to album art" feature were used to do this, very convenient, thanks.

Also adds
- a webui only startup flag if you just want to see what the webui looks like. (updated screenshots in the readme maybe?)
- detection of long response time, will show if aa-proxy-rs isn't keeping up with realtime.