### PR TITLE
main: fix mismatched break type in tokio_main connection loop

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -943,7 +943,7 @@ async fn tokio_main(
                 "{} 🛑 shutdown in progress, exiting main connection loop without reconnecting",
                 NAME
             );
-            break;
+            break Ok(());
         }
         if let Some(ref mut leds) = led_manager {
             leds.set_led(LedColor::Green, LedMode::Heartbeat).await;
@@ -1145,7 +1145,7 @@ async fn tokio_main(
                 "{} 🛑 shutdown in progress, exiting main connection loop without reconnecting",
                 NAME
             );
-            break;
+            break Ok(());
         }
 
         // Re-read config before reconnect handling so runtime config changes apply immediately.


### PR DESCRIPTION
## Summary

`cargo build` fails on this branch:

```
error[E0308]: mismatched types
   --> src/main.rs:946:13
    |
946 |             break;
    |             ^^^^^ expected `Result<(), Box<dyn Error + Send + Sync>>`, found `()`
```

The shutdown-requested early-exit checks added in d3a35e8 (prevent reconnect race on signal-triggered shutdown) use a bare `break;` inside the `tokio_main` connection loop. That loop is the tail expression of an `async fn` returning `Result<()>`. Before d3a35e8 the loop never broke — its type was `!`, which unifies with anything — so the mismatch was latent. Now that it does break, `()` doesn't unify with `Result<(), Box<dyn Error + Send + Sync>>`, and the build fails.

Fix: give both `break` sites an explicit `Ok(())`, matching the loop's expected break type.

## Changes

- `src/main.rs`: two occurrences of `break;` → `break Ok(());` in the two shutdown-requested checks inside the `tokio_main` connection loop.
