### PR TITLE
proxy: synchronize USB accessory open with gadget mode switch

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -648,6 +648,7 @@ async fn tokio_main(
     button_support: bool,
     profile_connected: Arc<AtomicBool>,
     usb_connected: Arc<AtomicBool>,
+    usb_accessory_ready: Arc<Notify>,
     ws_event_tx: broadcast::Sender<ServerEvent>,
     script_registry: Option<Arc<ScriptRegistry>>,
     web_only: bool,
@@ -965,6 +966,7 @@ async fn tokio_main(
                 tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                 continue;
             }
+            usb_accessory_ready.notify_one();
         }
 
         // run only if not handling this in handshake task
@@ -1131,6 +1133,7 @@ async fn tokio_main(
                 tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                 continue;
             }
+            usb_accessory_ready.notify_one();
         }
 
         // inform via LED about successful connection
@@ -1478,6 +1481,8 @@ fn main() -> Result<()> {
     let last_tire_pressure_data = Arc::new(RwLock::new(None));
     let usb_connected = Arc::new(AtomicBool::new(false));
     let usb_connected_cloned = usb_connected.clone();
+    let usb_accessory_ready = Arc::new(Notify::new());
+    let usb_accessory_ready_cloned = usb_accessory_ready.clone();
     let (ws_event_tx, _ws_event_rx) = broadcast::channel(256);
     let ws_event_tx_cloned = ws_event_tx.clone();
 
@@ -1559,6 +1564,7 @@ fn main() -> Result<()> {
             button_support,
             profile_connected_cloned,
             usb_connected_cloned,
+            usb_accessory_ready_cloned,
             ws_event_tx_cloned,
             script_registry_cloned,
             web_only,
@@ -1588,6 +1594,7 @@ fn main() -> Result<()> {
                 media_tap_endpoints,
                 companion_ip,
                 usb_connected,
+                usb_accessory_ready,
                 script_registry.clone(),
                 ws_event_tx.clone(),
                 shared_media_channels,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -56,6 +56,10 @@ const NAME: &str = "<i><bright-black> proxy: </>";
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 const USB_ACCESSORY_PATH: &str = "/dev/usb_accessory";
+// Bounded below the transfer-stall timeout (config.timeout_secs, default 10s) so a
+// missed/late notification can't outlast the stall detector, and above the observed
+// ~2-3s gadget-switch duration so the common case never actually waits this long.
+const USB_ACCESSORY_READY_TIMEOUT: Duration = Duration::from_secs(8);
 pub const BUFFER_LEN: usize = 16 * 1024;
 const TCP_CLIENT_TIMEOUT: Duration = Duration::new(30, 0);
 const COMP_APP_TCP_PORT: u16 = 9999;
@@ -662,6 +666,7 @@ pub async fn io_loop(
     media_tap_endpoints: SharedMediaTapEndpoints,
     companion_ip: SharedCompanionIp,
     usb_connected: Arc<AtomicBool>,
+    usb_accessory_ready: Arc<Notify>,
     script_registry: Option<Arc<ScriptRegistry>>,
     ws_event_tx: BroadcastSender<ServerEvent>,
     shared_media_channels: SharedMediaChannels,
@@ -862,6 +867,26 @@ pub async fn io_loop(
                 continue;
             }
         } else {
+            // The USB gadget switch to accessory mode (done by tokio_main /
+            // usb_gadget.rs) runs concurrently on a separate runtime and can
+            // take a couple of seconds. Opening the accessory node before that
+            // switch completes means no bytes ever reach the real UDC, which
+            // trips the stall-detection timeout above every single session.
+            // Wait for the "switched" signal first, bounded so a failed/skipped
+            // gadget switch elsewhere can't hang this loop forever.
+            if timeout(
+                USB_ACCESSORY_READY_TIMEOUT,
+                usb_accessory_ready.notified(),
+            )
+            .await
+            .is_err()
+            {
+                warn!(
+                    "{} ⏳ Timed out waiting for USB gadget accessory-switch signal; opening anyway",
+                    NAME
+                );
+            }
+
             info!(
                 "{} 📂 Opening USB accessory device: <u>{}</u>",
                 NAME, USB_ACCESSORY_PATH


### PR DESCRIPTION
## Summary

`io_loop` opens `/dev/usb_accessory` and starts proxying as soon as the phone's TCP connection is accepted — on a separate `tokio_uring` runtime from `tokio_main`, which drives the actual USB gadget switch to accessory mode (`enable_default_and_wait_for_accessory` in `usb_gadget.rs`). That switch takes ~2-3s and the two tasks never synchronized, so `io_loop` routinely opened the accessory node and began proxying **before** the head unit could see the Pi as a real USB accessory. No bytes reached the physical UDC during that window, which tripped the stall detector (`config.timeout_secs`, 10s default) on almost every session and forced a full Bluetooth/Wi-Fi/TCP/USB reconnect cycle.

Confirmed on real hardware (Volvo head unit): `Opening USB accessory device` logged ~2.3s *before* `Switched to accessory gadget`, every single cycle, followed by `unexpected transfer stall` at exactly 10s and a restart — 7-8 times in a row in the affected log.

## Fix

Add `usb_accessory_ready: Arc<Notify>`, shared between `tokio_main` and `io_loop` the same way `usb_connected` and `tcp_start` already are:

- `tokio_main` notifies it right after `enable_usb_if_present` confirms the gadget switch, for both `change_usb_order` orderings.
- `io_loop` waits on it **before** opening `/dev/usb_accessory`, bounded to 8s (under the 10s stall timeout, above the observed ~2-3s switch duration) so a failed or skipped gadget switch elsewhere can't hang the loop forever — it logs a warning and opens anyway if the wait times out.

## Changes

- `src/main.rs`: create the shared `Notify`, thread it through to `tokio_main`, call `notify_one()` after each successful gadget switch.
- `src/proxy.rs`: new `USB_ACCESSORY_READY_TIMEOUT` constant (8s), `io_loop` waits on the signal before opening the accessory device.

## Logs 

**Before** — `Opening USB accessory device` fires ~2.3s *before* `Switched to accessory gadget`, session dies at exactly 10s, every cycle (7-8 times in a row in the captured log):

```
00:00:19.726  bluetooth: stage #5 of 5: Received WifiConnectStatus frame from phone (⏱️ 12720 ms)
00:00:20.044  proxy:     TCP server: new client connected: 10.0.0.5:42316
00:00:20.058  proxy:     bt-wireless-proxy car-wifi-mitm: PHONE TCP accepted on MD listener; commit barrier seq=1
00:00:20.058  proxy:     📂 Opening USB accessory device: /dev/usb_accessory
00:00:20.059  proxy:     ♾️ Starting to proxy data between HU and MD...
00:00:22.351  usb:       🔌 USB Manager: Switched to accessory gadget      <-- 2.3s AFTER proxying started
00:00:30.068  ERROR proxy: 🔴 Connection error: unexpected transfer stall
00:00:30.071  proxy:     ⌛ session time: 10s 11ms 954us 49ns
00:00:30.071  main:      📵 TCP/USB connection closed or not started, trying again...
```

**After** — both lines land in the same millisecond, no stall, session runs well past the old 10s cutoff:

```
00:02:49.774  proxy:  📳 TCP server: new client connected: 10.0.0.5:40208
00:02:49.789  proxy:  🧪 bt-wireless-proxy car-wifi-mitm: PHONE TCP accepted on MD listener; commit barrier seq=1
00:02:52.508  usb:    🔌 USB Manager: Switched to accessory gadget
00:02:52.508  proxy:  📂 Opening USB accessory device: /dev/usb_accessory
00:02:52.508  proxy:  ♾️ Starting to proxy data between HU and MD...
# ... session continues, no "unexpected transfer stall" ...
09:11:15.025  proxy:  tcp_bridge[SWUPDATE]: error during bidirectional copy: Connection reset by peer (os error 104)
# ^ unrelated companion-app side channel, not the AA session — no reconnect triggered
```