### PR TITLE
config: log outcome of AppConfig::save() to disk

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,9 @@ use std::{fmt::Display, fs, io, path::PathBuf, str::FromStr, sync::Arc};
 use tokio::sync::RwLock;
 use toml_edit::{value, DocumentMut};
 
+// module name for logging engine
+const NAME: &str = "<i><bright-black> config: </>";
+
 // Device identity (Bluetooth alias + SSID)
 pub const IDENTITY_NAME: &str = "aa-proxy";
 #[macro_export]
@@ -1451,7 +1454,19 @@ impl AppConfig {
         doc["wasm_script_lifecycle_epoch_deadline"] =
             value(self.wasm_script_lifecycle_epoch_deadline as i64);
 
-        let _ = fs::write(config_file, doc.to_string());
+        match fs::write(&config_file, doc.to_string()) {
+            Ok(()) => {
+                info!("{} ⚙️ Configuration saved: {}", NAME, config_file.display());
+            }
+            Err(e) => {
+                error!(
+                    "{} 🔴 Failed to save configuration to {}: {}",
+                    NAME,
+                    config_file.display(),
+                    e
+                );
+            }
+        }
     }
 
     pub fn load_config_json() -> Result<ConfigJson, Box<dyn std::error::Error>> {


### PR DESCRIPTION
AppConfig::save() discarded the fs::write() result via `let _ = ...`, so a failed write (read-only /etc, disk full, permissions) was completely silent: the in-memory config was updated, callers assumed success, and the on-disk file could silently be left stale until the next restart reverted the change with no trace of why.

Log the outcome directly in save() rather than at each call site (web.rs's /config save handler and companion_bt.rs's auth-token provisioning), so every caller gets this for free: an info line confirming the path on success, an error line with the underlying io::Error on failure. Call sites are unchanged; save() still returns ().